### PR TITLE
Refactor to add more type support

### DIFF
--- a/pulp/Cargo.toml
+++ b/pulp/Cargo.toml
@@ -16,6 +16,7 @@ num-complex = { version = "0.4.4", default-features = false, features = ["bytemu
 libm = { version = "0.2", default-features = false }
 reborrow = "0.5"
 cfg-if = "1.0.0"
+paste = "1"
 
 [features]
 default = [

--- a/pulp/examples/basic.rs
+++ b/pulp/examples/basic.rs
@@ -20,6 +20,7 @@ mod x86 {
 	}
 
 	#[target_feature(enable = "avx512f")]
+	#[allow(clippy::missing_transmute_annotations)]
 	unsafe fn sum_stdarch_imp(v: &[f64]) -> f64 {
 		let mut acc0 = _mm512_set1_pd(0.0);
 		let mut acc1 = _mm512_set1_pd(0.0);

--- a/pulp/src/core_arch/aarch64/mod.rs
+++ b/pulp/src/core_arch/aarch64/mod.rs
@@ -10,6 +10,8 @@ macro_rules! __impl {
 		}
 
 		impl $name {
+			/// # Safety
+			/// Not checked
 			#[inline(always)]
 			pub unsafe fn new_unchecked() -> Self {
 				Self { __private: () }

--- a/pulp/src/x86.rs
+++ b/pulp/src/x86.rs
@@ -6,6 +6,457 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+macro_rules! x86_call_128 {
+	($ext: expr, $func: ident, f32, $($arg: expr),*) => {
+		paste!($ext.[<_mm_ $func _ ps>]($($arg),*))
+	};
+	($ext: expr, $func: ident, f64, $($arg: expr),*) => {
+		paste!($ext.[<_mm_ $func _ pd>]($($arg),*))
+	};
+	($ext: expr, $func: ident, $ty: ty, $($arg: expr),*) => {
+		paste!($ext.[<_mm_ $func _ep $ty>]($($arg),*))
+	}
+}
+pub(crate) use x86_call_128;
+
+macro_rules! x86_call_256 {
+	($ext: expr, $func: ident, f32, $($arg: expr),*) => {
+		paste!($ext.[<_mm256_ $func _ ps>]($($arg),*))
+	};
+	($ext: expr, $func: ident, f64, $($arg: expr),*) => {
+		paste!($ext.[<_mm256_ $func _ pd>]($($arg),*))
+	};
+	($ext: expr, $func: ident, $ty: ty, $($arg: expr),*) => {
+		paste!($ext.[<_mm256_ $func _ep $ty>]($($arg),*))
+	}
+}
+pub(crate) use x86_call_256;
+
+macro_rules! x86_call_512 {
+	($ext: expr, $func: ident, f32, $($arg: expr),*) => {
+		paste!($ext.[<_mm512_ $func _ ps>]($($arg),*))
+	};
+	($ext: expr, $func: ident, f64, $($arg: expr),*) => {
+		paste!($ext.[<_mm512_ $func _ pd>]($($arg),*))
+	};
+	($ext: expr, $func: ident, $ty: ty, $($arg: expr),*) => {
+		paste!($ext.[<_mm512_ $func _ep $ty>]($($arg),*))
+	}
+}
+pub(crate) use x86_call_512;
+
+macro_rules! x86_call_512_mask {
+	($ext: expr, $func: ident, f32, $($arg: expr),*) => {
+		paste!($ext.[<_mm512_ $func _ ps_mask>]($($arg),*))
+	};
+	($ext: expr, $func: ident, f64, $($arg: expr),*) => {
+		paste!($ext.[<_mm512_ $func _ pd_mask>]($($arg),*))
+	};
+	($ext: expr, $func: ident, $ty: ty, $($arg: expr),*) => {
+		paste!($ext.[<_mm512_ $func _ep $ty _mask>]($($arg),*))
+	}
+}
+pub(crate) use x86_call_512_mask;
+
+macro_rules! x86_call_128_nosign {
+	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, u16, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, u32, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, u64, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, m8, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, m16, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, m32, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, m64, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, $ty: ident, $($arg: expr),*) => {
+		x86_call_128!($ext, $func, $ty, $($arg),*)
+	};
+}
+pub(crate) use x86_call_128_nosign;
+
+macro_rules! x86_call_256_nosign {
+	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, u16, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, u32, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, u64, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, m8, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, m16, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, m32, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, m64, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, $ty: ident, $($arg: expr),*) => {
+		x86_call_256!($ext, $func, $ty, $($arg),*)
+	};
+}
+pub(crate) use x86_call_256_nosign;
+
+macro_rules! x86_call_512_nosign {
+	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, u16, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, u32, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, u64, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, m8, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, m16, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, m32, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, m64, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, $ty: ident, $($arg: expr),*) => {
+		x86_call_512!($ext, $func, $ty, $($arg),*)
+	};
+}
+pub(crate) use x86_call_512_nosign;
+
+macro_rules! x86_call_512_nosign_mask {
+	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, u16, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, u32, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, u64, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, m8, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i8, $($arg),*)
+	};
+	($ext: expr, $func: ident, m16, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i16, $($arg),*)
+	};
+	($ext: expr, $func: ident, m32, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i32, $($arg),*)
+	};
+	($ext: expr, $func: ident, m64, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, i64, $($arg),*)
+	};
+	($ext: expr, $func: ident, $ty: ident, $($arg: expr),*) => {
+		x86_call_512_mask!($ext, $func, $ty, $($arg),*)
+	};
+}
+pub(crate) use x86_call_512_nosign_mask;
+
+macro_rules! binop_128 {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
+				cast!(x86_call_128!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
+		$(binop_128!($func, $op, $doc, $ty, $out, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_128!($op, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_128!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_128;
+
+macro_rules! binop_256 {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
+				cast!(x86_call_256!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
+		$(binop_256!($func, $op, $doc, $ty, $out, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_256!($op, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_256!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_256;
+
+macro_rules! binop_512 {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
+				cast!(x86_call_512!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
+		$(binop_512!($func, $op, $doc, $ty, $out, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_512!($op, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_512!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_512;
+
+macro_rules! unop_128 {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>]) -> [<$ty x $factor>] {
+				cast!(x86_call_128!(self.$ext, $op, $ty, cast!(a)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(unop_128!($op, $op, $doc, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(unop_128!($func, $op, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use unop_128;
+
+macro_rules! unop_256 {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>]) -> [<$ty x $factor>] {
+				cast!(x86_call_256!(self.$ext, $op, $ty, cast!(a)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(unop_256!($op, $op, $doc, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(unop_256!($func, $op, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use unop_256;
+
+macro_rules! unop_512 {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>]) -> [<$ty x $factor>] {
+				cast!(x86_call_512!(self.$ext, $op, $ty, cast!(a)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(unop_512!($op, $op, $doc, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(unop_512!($func, $op, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use unop_512;
+
+macro_rules! binop_128_nosign {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
+				cast!(x86_call_128_nosign!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
+		$(binop_128_nosign!($func, $op, $doc, $ty, $out, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_128_nosign!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_128_nosign!($func, $func, $doc, $ty, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_128_nosign;
+
+macro_rules! binop_256_nosign {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
+				cast!(x86_call_256_nosign!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
+		$(binop_256_nosign!($func, $op, $doc, $ty, $out, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_256_nosign!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_256_nosign!($func, $func, $doc, $ty, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_256_nosign;
+
+macro_rules! binop_512_nosign {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
+				cast!(x86_call_512_nosign!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
+		$(binop_512_nosign!($func, $op, $doc, $ty, $out, $factor, $ext);)*
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_nosign!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_nosign!($func, $func, $doc, $ty, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_512_nosign;
+
+macro_rules! binop_512_nosign_mask {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<b $factor>] {
+				cast!(x86_call_512_nosign_mask!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_nosign_mask!($func, $op, $doc, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_nosign_mask!($func, $func, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_512_nosign_mask;
+
+macro_rules! binop_512_mask {
+	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<b $factor>] {
+				cast!(x86_call_512_mask!(self.$ext, $op, $ty, cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_mask!($func, $op, $doc, $ty, $factor, $ext);)*
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_mask!($func, $func, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_512_mask;
+
+macro_rules! binop_128_full {
+	($func: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$ty x $factor>] {
+				cast!(self.$ext.[<_mm_ $func _si128>](cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_128_full!($func, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_128_full;
+
+macro_rules! binop_256_full {
+	($func: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$ty x $factor>] {
+				cast!(self.$ext.[<_mm256_ $func _si256>](cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_256_full!($func, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_256_full;
+
+macro_rules! binop_512_full {
+	($func: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
+		paste! {
+			#[inline(always)]
+			#[doc = $doc]
+			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$ty x $factor>] {
+				cast!(self.$ext.[<_mm512_ $func _si512>](cast!(a), cast!(b)))
+			}
+		}
+	};
+	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
+		$(binop_512_full!($func, $doc, $ty, $factor, $ext);)*
+	};
+}
+pub(crate) use binop_512_full;
+
 mod v2;
 mod v3;
 

--- a/pulp/src/x86.rs
+++ b/pulp/src/x86.rs
@@ -32,32 +32,6 @@ macro_rules! x86_call_256 {
 }
 pub(crate) use x86_call_256;
 
-macro_rules! x86_call_512 {
-	($ext: expr, $func: ident, f32, $($arg: expr),*) => {
-		paste!($ext.[<_mm512_ $func _ ps>]($($arg),*))
-	};
-	($ext: expr, $func: ident, f64, $($arg: expr),*) => {
-		paste!($ext.[<_mm512_ $func _ pd>]($($arg),*))
-	};
-	($ext: expr, $func: ident, $ty: ty, $($arg: expr),*) => {
-		paste!($ext.[<_mm512_ $func _ep $ty>]($($arg),*))
-	}
-}
-pub(crate) use x86_call_512;
-
-macro_rules! x86_call_512_mask {
-	($ext: expr, $func: ident, f32, $($arg: expr),*) => {
-		paste!($ext.[<_mm512_ $func _ ps_mask>]($($arg),*))
-	};
-	($ext: expr, $func: ident, f64, $($arg: expr),*) => {
-		paste!($ext.[<_mm512_ $func _ pd_mask>]($($arg),*))
-	};
-	($ext: expr, $func: ident, $ty: ty, $($arg: expr),*) => {
-		paste!($ext.[<_mm512_ $func _ep $ty _mask>]($($arg),*))
-	}
-}
-pub(crate) use x86_call_512_mask;
-
 macro_rules! x86_call_128_nosign {
 	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
 		x86_call_128!($ext, $func, i8, $($arg),*)
@@ -120,68 +94,6 @@ macro_rules! x86_call_256_nosign {
 }
 pub(crate) use x86_call_256_nosign;
 
-macro_rules! x86_call_512_nosign {
-	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i8, $($arg),*)
-	};
-	($ext: expr, $func: ident, u16, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i16, $($arg),*)
-	};
-	($ext: expr, $func: ident, u32, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i32, $($arg),*)
-	};
-	($ext: expr, $func: ident, u64, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i64, $($arg),*)
-	};
-	($ext: expr, $func: ident, m8, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i8, $($arg),*)
-	};
-	($ext: expr, $func: ident, m16, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i16, $($arg),*)
-	};
-	($ext: expr, $func: ident, m32, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i32, $($arg),*)
-	};
-	($ext: expr, $func: ident, m64, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, i64, $($arg),*)
-	};
-	($ext: expr, $func: ident, $ty: ident, $($arg: expr),*) => {
-		x86_call_512!($ext, $func, $ty, $($arg),*)
-	};
-}
-pub(crate) use x86_call_512_nosign;
-
-macro_rules! x86_call_512_nosign_mask {
-	($ext: expr, $func: ident, u8, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i8, $($arg),*)
-	};
-	($ext: expr, $func: ident, u16, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i16, $($arg),*)
-	};
-	($ext: expr, $func: ident, u32, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i32, $($arg),*)
-	};
-	($ext: expr, $func: ident, u64, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i64, $($arg),*)
-	};
-	($ext: expr, $func: ident, m8, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i8, $($arg),*)
-	};
-	($ext: expr, $func: ident, m16, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i16, $($arg),*)
-	};
-	($ext: expr, $func: ident, m32, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i32, $($arg),*)
-	};
-	($ext: expr, $func: ident, m64, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, i64, $($arg),*)
-	};
-	($ext: expr, $func: ident, $ty: ident, $($arg: expr),*) => {
-		x86_call_512_mask!($ext, $func, $ty, $($arg),*)
-	};
-}
-pub(crate) use x86_call_512_nosign_mask;
-
 macro_rules! binop_128 {
 	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
 		paste! {
@@ -226,28 +138,6 @@ macro_rules! binop_256 {
 }
 pub(crate) use binop_256;
 
-macro_rules! binop_512 {
-	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
-		paste! {
-			#[inline(always)]
-			#[doc = $doc]
-			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
-				cast!(x86_call_512!(self.$ext, $op, $ty, cast!(a), cast!(b)))
-			}
-		}
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
-		$(binop_512!($func, $op, $doc, $ty, $out, $factor, $ext);)*
-	};
-	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
-		$(binop_512!($op, $op, $doc, $ty, $ty, $factor, $ext);)*
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
-		$(binop_512!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
-	};
-}
-pub(crate) use binop_512;
-
 macro_rules! unop_128 {
 	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
 		paste! {
@@ -285,25 +175,6 @@ macro_rules! unop_256 {
 	};
 }
 pub(crate) use unop_256;
-
-macro_rules! unop_512 {
-	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
-		paste! {
-			#[inline(always)]
-			#[doc = $doc]
-			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>]) -> [<$ty x $factor>] {
-				cast!(x86_call_512!(self.$ext, $op, $ty, cast!(a)))
-			}
-		}
-	};
-	($ext: ident: $op: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
-		$(unop_512!($op, $op, $doc, $ty, $factor, $ext);)*
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
-		$(unop_512!($func, $op, $doc, $ty, $factor, $ext);)*
-	};
-}
-pub(crate) use unop_512;
 
 macro_rules! binop_128_nosign {
 	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
@@ -349,66 +220,6 @@ macro_rules! binop_256_nosign {
 }
 pub(crate) use binop_256_nosign;
 
-macro_rules! binop_512_nosign {
-	($func: ident, $op: ident, $doc: literal, $ty: ident, $out: ident, $factor: literal, $ext: ident) => {
-		paste! {
-			#[inline(always)]
-			#[doc = $doc]
-			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$out x $factor>] {
-				cast!(x86_call_512_nosign!(self.$ext, $op, $ty, cast!(a), cast!(b)))
-			}
-		}
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal => $out: ident),*) => {
-		$(binop_512_nosign!($func, $op, $doc, $ty, $out, $factor, $ext);)*
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_nosign!($func, $op, $doc, $ty, $ty, $factor, $ext);)*
-	};
-	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_nosign!($func, $func, $doc, $ty, $ty, $factor, $ext);)*
-	};
-}
-pub(crate) use binop_512_nosign;
-
-macro_rules! binop_512_nosign_mask {
-	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
-		paste! {
-			#[inline(always)]
-			#[doc = $doc]
-			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<b $factor>] {
-				cast!(x86_call_512_nosign_mask!(self.$ext, $op, $ty, cast!(a), cast!(b)))
-			}
-		}
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_nosign_mask!($func, $op, $doc, $ty, $factor, $ext);)*
-	};
-	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_nosign_mask!($func, $func, $doc, $ty, $factor, $ext);)*
-	};
-}
-pub(crate) use binop_512_nosign_mask;
-
-macro_rules! binop_512_mask {
-	($func: ident, $op: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
-		paste! {
-			#[inline(always)]
-			#[doc = $doc]
-			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<b $factor>] {
-				cast!(x86_call_512_mask!(self.$ext, $op, $ty, cast!(a), cast!(b)))
-			}
-		}
-	};
-	($ext: ident: $op: ident, $doc: literal, $func: ident, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_mask!($func, $op, $doc, $ty, $factor, $ext);)*
-	};
-	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_mask!($func, $func, $doc, $ty, $factor, $ext);)*
-	};
-}
-pub(crate) use binop_512_mask;
-
 macro_rules! binop_128_full {
 	($func: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
 		paste! {
@@ -440,22 +251,6 @@ macro_rules! binop_256_full {
 	};
 }
 pub(crate) use binop_256_full;
-
-macro_rules! binop_512_full {
-	($func: ident, $doc: literal, $ty: ident, $factor: literal, $ext: ident) => {
-		paste! {
-			#[inline(always)]
-			#[doc = $doc]
-			pub fn [<$func _ $ty x $factor>](self, a: [<$ty x $factor>], b: [<$ty x $factor>]) -> [<$ty x $factor>] {
-				cast!(self.$ext.[<_mm512_ $func _si512>](cast!(a), cast!(b)))
-			}
-		}
-	};
-	($ext: ident: $func: ident, $doc: literal, $($ty: ident x $factor: literal),*) => {
-		$(binop_512_full!($func, $doc, $ty, $factor, $ext);)*
-	};
-}
-pub(crate) use binop_512_full;
 
 mod v2;
 mod v3;

--- a/pulp/src/x86/v2.rs
+++ b/pulp/src/x86/v2.rs
@@ -19,6 +19,137 @@ simd_type!({
 impl Seal for V2 {}
 
 impl V2 {
+	binop_128_nosign!(sse: add, "Computes `a + b` for each lane of `a` and `b`.", f32 x 4);
+
+	binop_128_nosign!(sse2: add, "Adds the elements of each lane of `a` and `b`.", f64 x 2);
+
+	binop_128_nosign!(sse2: add, "Adds the elements of each lane of `a` and `b`, with wrapping on overflow.", wrapping_add, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, u64 x 2, i64 x 2);
+
+	binop_128!(sse: and, "Returns `a & b` for each bit in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: and, "Returns `a & b` for each bit in `a` and `b`.", f64 x 2);
+
+	binop_128_full!(sse2: and, "Returns `a & b` for each bit in `a` and `b`.", m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2);
+
+	binop_128!(sse: andnot, "Returns `!a & b` for each bit in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: andnot, "Returns `!a & b` for each bit in `a` and `b`.", f64 x 2);
+
+	binop_128_full!(sse2: andnot, "Returns `!a & b` for each bit in `a` and `b`.", m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2);
+
+	binop_128!(ssse3: sign, r#"Applies the sign of each element of `sign` to the corresponding lane in `a`.
+- If `sign` is zero, the corresponding element is zeroed.
+- If `sign` is positive, the corresponding element is returned as is.
+- If `sign` is negative, the corresponding element is negated."#, apply_sign, i8 x 16, i16 x 8, i32 x 4);
+
+	binop_128!(sse2: avg, "Computes `average(a, b)` for each lane of `a` and `b`.", average, u8 x 16, u16 x 8);
+
+	unop_128!(sse4_1: ceil, "Returns `ceil(a)` for each lane of `a`, rounding towards positive infinity.", f32 x 4, f64 x 2);
+
+	binop_128_nosign!(sse: cmpeq, "Compares the elements in each lane of `a` and `b` for equality.", cmp_eq, f32 x 4 => m32);
+
+	binop_128_nosign!(sse2: cmpeq, "Compares the elements in each lane of `a` and `b` for equality.", cmp_eq, m8 x 16 => m8, u8 x 16 => m8, i8 x 16 => m8, m16 x 8 => m16, u16 x 8 => m16, i16 x 8 => m16, m32 x 4 => m32, u32 x 4 => m32, i32 x 4 => m32, f64 x 2 => m64);
+
+	binop_128_nosign!(sse4_1: cmpeq, "Compares the elements in each lane of `a` and `b` for equality.", cmp_eq, m64 x 2 => m64, u64 x 2 => m64, i64 x 2 => m64);
+
+	binop_128!(sse: cmpge, "Compares the elements in each lane of `a` and `b` for greater-than-or-equal-to.", cmp_ge, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpge, "Compares the elements in each lane of `a` and `b` for greater-than-or-equal-to.", cmp_ge, f64 x 2 => m64);
+
+	binop_128!(sse: cmpgt, "Compares the elements in each lane of `a` and `b` for greater-than.", cmp_gt, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpgt, "Compares the elements in each lane of `a` and `b` for equality.", cmp_gt, i8 x 16 => m8, i16 x 8 => m16, i32 x 4 => m32, f64 x 2 => m64);
+
+	binop_128!(sse4_2: cmpgt, "Compares the elements in each lane of `a` and `b` for equality.", cmp_gt, i64 x 2 => m64);
+
+	binop_128!(sse: cmplt, "Compares the elements in each lane of `a` and `b` for greater-than.", cmp_lt, f32 x 4 => m32);
+
+	binop_128!(sse2: cmplt, "Compares the elements in each lane of `a` and `b` for less-than.", cmp_lt, i8 x 16 => m8, i16 x 8 => m16, i32 x 4 => m32, f64 x 2 => m64);
+
+	binop_128!(sse: cmple, "Compares the elements in each lane of `a` and `b` for less-than-or-equal-to.", cmp_le, f32 x 4 => m32);
+
+	binop_128!(sse2: cmple, "Compares the elements in each lane of `a` and `b` for less-than-or-equal-to.", cmp_le, f64 x 2 => m64);
+
+	binop_128!(sse: cmpneq, "Compares the elements in each lane of `a` and `b` for inequality.", cmp_not_eq, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpneq, "Compares the elements in each lane of `a` and `b` for inequality.", cmp_not_eq, f64 x 2 => m64);
+
+	binop_128!(sse: cmpnge, "Compares the elements in each lane of `a` and `b` for not-greater-than-or-equal.", cmp_not_ge, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpnge, "Compares the elements in each lane of `a` and `b` for not-greater-than-or-equal.", cmp_not_ge, f64 x 2 => m64);
+
+	binop_128!(sse: cmpngt, "Compares the elements in each lane of `a` and `b` for not-greater-than.", cmp_not_gt, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpngt, "Compares the elements in each lane of `a` and `b` for not-greater-than.", cmp_not_gt, f64 x 2 => m64);
+
+	binop_128!(sse: cmpnle, "Compares the elements in each lane of `a` and `b` for not-less-than-or-equal.", cmp_not_le, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpnle, "Compares the elements in each lane of `a` and `b` for not-less-than-or-equal.", cmp_not_le, f64 x 2 => m64);
+
+	binop_128!(sse: cmpnlt, "Compares the elements in each lane of `a` and `b` for not-less-than.", cmp_not_lt, f32 x 4 => m32);
+
+	binop_128!(sse2: cmpnlt, "Compares the elements in each lane of `a` and `b` for not-less-than.", cmp_not_lt, f64 x 2 => m64);
+
+	binop_128!(sse: div, "Divides the elements of each lane of `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: div, "Divides the elements of each lane of `a` and `b`.", f64 x 2);
+
+	unop_128!(sse4_1: floor, "Rounds the elements of each lane of `a` to the nearest integer towards negative infinity.", f32 x 4, f64 x 2);
+
+	binop_128_nosign!(sse3: hadd, "[_mm_hadd_ps](core::arch::x86_64::_mm_hadd_ps)", horizontal_add_pack, f32 x 4, f64 x 2);
+
+	binop_128_nosign!(ssse3: hadd, "[_mm_hadd_ps](core::arch::x86_64::_mm_hadd_ps)", horizontal_add_pack, u16 x 8, i16 x 8, u32 x 4, i32 x 4);
+
+	binop_128_nosign!(sse3: hsub, "[_mm_hsub_ps](core::arch::x86_64::_mm_hsub_ps)", horizontal_sub_pack, f32 x 4, f64 x 2);
+
+	binop_128_nosign!(ssse3: hsub, "[_mm_hsub_ps](core::arch::x86_64::_mm_hsub_ps)", horizontal_sub_pack, u16 x 8, i16 x 8, u32 x 4, i32 x 4);
+
+	binop_128!(sse: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", u8 x 16, i16 x 8, f64 x 2);
+
+	binop_128!(sse4_1: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", i8 x 16, u16 x 8, u32 x 4, i32 x 4);
+
+	binop_128!(sse: min, "Computes `max(a, b)`. for each lane in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: min, "Computes `max(a, b)`. for each lane in `a` and `b`.", u8 x 16, i16 x 8, f64 x 2);
+
+	binop_128!(sse4_1: min, "Computes `max(a, b)`. for each lane in `a` and `b`.", i8 x 16, u16 x 8, u32 x 4, i32 x 4);
+
+	binop_128!(sse: mul, "Computes `a * b` for each lane in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: mul, "Computes `a * b` for each lane in `a` and `b`.", f64 x 2);
+
+	binop_128_nosign!(sse2: mullo, "Computes `a * b` for each lane in `a` and `b`, with wrapping overflow.", wrapping_mul, u16 x 8, i16 x 8);
+
+	binop_128_nosign!(sse4_1: mullo, "Computes `a * b` for each lane in `a` and `b`, with wrapping overflow.", wrapping_mul, u32 x 4, i32 x 4);
+
+	binop_128!(sse: or, "Returns `a | b` for each bit in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: or, "Returns `a | b` for each bit in `a` and `b`.", f64 x 2);
+
+	binop_128_full!(sse2: or, "Returns `a | b` for each bit in `a` and `b`.", m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2);
+
+	binop_128!(sse2: adds, "Adds the elements of each lane of `a` and `b`, with saturation.", saturating_add, u8 x 16, i8 x 16, u16 x 8, i16 x 8);
+
+	binop_128!(sse2: subs, "Subtracts the elements of each lane of `a` and `b`, with saturation.", saturating_sub, u8 x 16, i8 x 16, u16 x 8, i16 x 8);
+
+	binop_128_nosign!(sse: sub, "Subtracts the elements of each lane of `a` and `b`.", f32 x 4);
+
+	binop_128_nosign!(sse2: sub, "Subtracts the elements of each lane of `a` and `b`.", f64 x 2);
+
+	binop_128_nosign!(sse2: sub, "Subtracts the elements of each lane of `a` and `b`, with wrapping overflow.", wrapping_sub, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, u64 x 2, i64 x 2);
+
+	binop_128!(sse3: addsub, "Alternatively subtracts and adds the elements of each lane of `a` and `b`.", subadd, f32 x 4, f64 x 2);
+
+	unop_128!(ssse3: abs, "Computes the unsigned absolute value of the elements of each lane of `a`.", unsigned_abs, i8 x 16, i16 x 8, i32 x 4);
+
+	binop_128!(sse: xor, "Returns `a ^ b` for each bit in `a` and `b`.", f32 x 4);
+
+	binop_128!(sse2: xor, "Returns `a ^ b` for each bit in `a` and `b`.", f64 x 2);
+
+	binop_128_full!(sse2: xor, "Returns `a ^ b` for each bit in `a` and `b`.", m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2);
+
 	/// Computes `abs(a)` for each lane of `a`.
 	#[inline(always)]
 	pub fn abs_f32x4(self, a: f32x4) -> f32x4 {
@@ -31,213 +162,6 @@ impl V2 {
 		self.and_f64x2(a, cast!(self.splat_u64x2((1 << 63) - 1)))
 	}
 
-	/// Computes `a + b` for each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn add_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_add_ps(cast!(a), cast!(b)))
-	}
-
-	/// Computes `a + b` for each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn add_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_add_pd(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_and_ps(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_and_pd(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_m16x8(self, a: m16x8, b: m16x8) -> m16x8 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_m32x4(self, a: m32x4, b: m32x4) -> m32x4 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_m64x2(self, a: m64x2, b: m64x2) -> m64x2 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_m8x16(self, a: m8x16, b: m8x16) -> m8x16 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn and_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_and_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_andnot_ps(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_andnot_pd(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_m16x8(self, a: m16x8, b: m16x8) -> m16x8 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_m32x4(self, a: m32x4, b: m32x4) -> m32x4 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_m64x2(self, a: m64x2, b: m64x2) -> m64x2 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_m8x16(self, a: m8x16, b: m8x16) -> m8x16 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `!a & b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_andnot_si128(cast!(a), cast!(b)))
-	}
-
-	/// Applies the sign of each element of `sign` to the corresponding lane in `a`.
-	/// - If `sign` is zero, the corresponding element is zeroed.
-	/// - If `sign` is positive, the corresponding element is returned as is.
-	/// - If `sign` is negative, the corresponding element is negated.
-	#[inline(always)]
-	pub fn apply_sign_i16x8(self, sign: i16x8, a: i16x8) -> i16x8 {
-		cast!(self.ssse3._mm_sign_epi16(cast!(a), cast!(sign)))
-	}
-
-	/// Applies the sign of each element of `sign` to the corresponding lane in `a`.
-	/// - If `sign` is zero, the corresponding element is zeroed.
-	/// - If `sign` is positive, the corresponding element is returned as is.
-	/// - If `sign` is negative, the corresponding element is negated.
-	#[inline(always)]
-	pub fn apply_sign_i32x4(self, sign: i32x4, a: i32x4) -> i32x4 {
-		cast!(self.ssse3._mm_sign_epi32(cast!(a), cast!(sign)))
-	}
-
-	/// Applies the sign of each element of `sign` to the corresponding lane in `a`.
-	/// - If `sign` is zero, the corresponding element is zeroed.
-	/// - If `sign` is positive, the corresponding element is returned as is.
-	/// - If `sign` is negative, the corresponding element is negated.
-	#[inline(always)]
-	pub fn apply_sign_i8x16(self, sign: i8x16, a: i8x16) -> i8x16 {
-		cast!(self.ssse3._mm_sign_epi8(cast!(a), cast!(sign)))
-	}
-
 	/// Computes the approximate reciprocal of the elements of each lane of `a`.
 	#[inline(always)]
 	pub fn approx_reciprocal_f32x4(self, a: f32x4) -> f32x4 {
@@ -248,102 +172,6 @@ impl V2 {
 	#[inline(always)]
 	pub fn approx_reciprocal_sqrt_f32x4(self, a: f32x4) -> f32x4 {
 		cast!(self.sse._mm_rsqrt_ps(cast!(a)))
-	}
-
-	/// Computes `average(a, b)` for each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn average_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_avg_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Computes `average(a, b)` for each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn average_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_avg_epu8(cast!(a), cast!(b)))
-	}
-
-	/// Returns `ceil(a)` for each lane of `a`, rounding towards positive infinity.
-	#[inline(always)]
-	pub fn ceil_f32x4(self, a: f32x4) -> f32x4 {
-		cast!(self.sse4_1._mm_ceil_ps(cast!(a)))
-	}
-
-	/// Returns `ceil(a)` for each lane of `a`, rounding towards positive infinity.
-	#[inline(always)]
-	pub fn ceil_f64x2(self, a: f64x2) -> f64x2 {
-		cast!(self.sse4_1._mm_ceil_pd(cast!(a)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpeq_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpeq_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_i16x8(self, a: i16x8, b: i16x8) -> m16x8 {
-		cast!(self.sse2._mm_cmpeq_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_i32x4(self, a: i32x4, b: i32x4) -> m32x4 {
-		cast!(self.sse2._mm_cmpeq_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_i64x2(self, a: i64x2, b: i64x2) -> m64x2 {
-		cast!(self.sse4_1._mm_cmpeq_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_i8x16(self, a: i8x16, b: i8x16) -> m8x16 {
-		cast!(self.sse2._mm_cmpeq_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u16x8(self, a: u16x8, b: u16x8) -> m16x8 {
-		cast!(self.sse2._mm_cmpeq_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u32x4(self, a: u32x4, b: u32x4) -> m32x4 {
-		cast!(self.sse2._mm_cmpeq_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u64x2(self, a: u64x2, b: u64x2) -> m64x2 {
-		cast!(self.sse4_1._mm_cmpeq_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u8x16(self, a: u8x16, b: u8x16) -> m8x16 {
-		cast!(self.sse2._mm_cmpeq_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than-or-equal-to.
-	#[inline(always)]
-	pub fn cmp_ge_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpge_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than-or-equal-to.
-	#[inline(always)]
-	pub fn cmp_ge_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpge_pd(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than-or-equal-to.
@@ -396,42 +224,6 @@ impl V2 {
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than.
 	#[inline(always)]
-	pub fn cmp_gt_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpgt_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpgt_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_i16x8(self, a: i16x8, b: i16x8) -> m16x8 {
-		cast!(self.sse2._mm_cmpgt_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_i32x4(self, a: i32x4, b: i32x4) -> m32x4 {
-		cast!(self.sse2._mm_cmpgt_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_i64x2(self, a: i64x2, b: i64x2) -> m64x2 {
-		cast!(self.sse4_2._mm_cmpgt_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_i8x16(self, a: i8x16, b: i8x16) -> m8x16 {
-		cast!(self.sse2._mm_cmpgt_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
 	pub fn cmp_gt_u16x8(self, a: u16x8, b: u16x8) -> m16x8 {
 		let k = self.splat_u16x8(0x8000);
 		self.cmp_gt_i16x8(cast!(self.xor_u16x8(a, k)), cast!(self.xor_u16x8(b, k)))
@@ -456,18 +248,6 @@ impl V2 {
 	pub fn cmp_gt_u8x16(self, a: u8x16, b: u8x16) -> m8x16 {
 		let k = self.splat_u8x16(0x80);
 		self.cmp_gt_i8x16(cast!(self.xor_u8x16(a, k)), cast!(self.xor_u8x16(b, k)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than-or-equal-to.
-	#[inline(always)]
-	pub fn cmp_le_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmple_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than-or-equal-to.
-	#[inline(always)]
-	pub fn cmp_le_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmple_pd(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for less-than-or-equal-to.
@@ -520,38 +300,8 @@ impl V2 {
 
 	/// Compares the elements in each lane of `a` and `b` for less-than.
 	#[inline(always)]
-	pub fn cmp_lt_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmplt_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than.
-	#[inline(always)]
-	pub fn cmp_lt_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmplt_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than.
-	#[inline(always)]
-	pub fn cmp_lt_i16x8(self, a: i16x8, b: i16x8) -> m16x8 {
-		cast!(self.sse2._mm_cmplt_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than.
-	#[inline(always)]
-	pub fn cmp_lt_i32x4(self, a: i32x4, b: i32x4) -> m32x4 {
-		cast!(self.sse2._mm_cmplt_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than.
-	#[inline(always)]
 	pub fn cmp_lt_i64x2(self, a: i64x2, b: i64x2) -> m64x2 {
 		cast!(self.sse4_2._mm_cmpgt_epi64(cast!(b), cast!(a)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for less-than.
-	#[inline(always)]
-	pub fn cmp_lt_i8x16(self, a: i8x16, b: i8x16) -> m8x16 {
-		cast!(self.sse2._mm_cmplt_epi8(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for less-than.
@@ -580,66 +330,6 @@ impl V2 {
 	pub fn cmp_lt_u8x16(self, a: u8x16, b: u8x16) -> m8x16 {
 		let k = self.splat_u8x16(0x80);
 		self.cmp_lt_i8x16(cast!(self.xor_u8x16(a, k)), cast!(self.xor_u8x16(b, k)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for inequality.
-	#[inline(always)]
-	pub fn cmp_not_eq_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpneq_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for inequality.
-	#[inline(always)]
-	pub fn cmp_not_eq_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpneq_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-greater-than-or-equal.
-	#[inline(always)]
-	pub fn cmp_not_ge_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpnge_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-greater-than-or-equal.
-	#[inline(always)]
-	pub fn cmp_not_ge_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpnge_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-greater-than.
-	#[inline(always)]
-	pub fn cmp_not_gt_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpngt_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-greater-than.
-	#[inline(always)]
-	pub fn cmp_not_gt_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpngt_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-less-than-or-equal.
-	#[inline(always)]
-	pub fn cmp_not_le_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpnle_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-less-than-or-equal.
-	#[inline(always)]
-	pub fn cmp_not_le_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpnle_pd(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-less-than.
-	#[inline(always)]
-	pub fn cmp_not_lt_f32x4(self, a: f32x4, b: f32x4) -> m32x4 {
-		cast!(self.sse._mm_cmpnlt_ps(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for not-less-than.
-	#[inline(always)]
-	pub fn cmp_not_lt_f64x2(self, a: f64x2, b: f64x2) -> m64x2 {
-		cast!(self.sse2._mm_cmpnlt_pd(cast!(a), cast!(b)))
 	}
 
 	/// Converts a `f32x4` to `f64x2`, elementwise, while truncating the extra elements.
@@ -858,62 +548,6 @@ impl V2 {
 		cast!(self.sse4_1._mm_cvtepu8_epi64(cast!(a)))
 	}
 
-	/// Divides the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn div_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_div_ps(cast!(a), cast!(b)))
-	}
-
-	/// Divides the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn div_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_div_pd(cast!(a), cast!(b)))
-	}
-
-	/// Rounds the elements of each lane of `a` to the nearest integer towards negative infinity.
-	#[inline(always)]
-	pub fn floor_f32x4(self, a: f32x4) -> f32x4 {
-		cast!(self.sse4_1._mm_floor_ps(cast!(a)))
-	}
-
-	/// Rounds the elements of each lane of `a` to the nearest integer towards negative infinity.
-	#[inline(always)]
-	pub fn floor_f64x2(self, a: f64x2) -> f64x2 {
-		cast!(self.sse4_1._mm_floor_pd(cast!(a)))
-	}
-
-	/// See [_mm_hadd_ps].
-	///
-	/// [_mm_hadd_ps]: core::arch::x86_64::_mm_hadd_ps
-	#[inline(always)]
-	pub fn horizontal_add_pack_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse3._mm_hadd_ps(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hadd_pd].
-	///
-	/// [_mm_hadd_pd]: core::arch::x86_64::_mm_hadd_pd
-	#[inline(always)]
-	pub fn horizontal_add_pack_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse3._mm_hadd_pd(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hadd_epi16].
-	///
-	/// [_mm_hadd_epi16]: core::arch::x86_64::_mm_hadd_epi16
-	#[inline(always)]
-	pub fn horizontal_add_pack_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.ssse3._mm_hadd_epi16(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hadd_epi32].
-	///
-	/// [_mm_hadd_epi32]: core::arch::x86_64::_mm_hadd_epi32
-	#[inline(always)]
-	pub fn horizontal_add_pack_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.ssse3._mm_hadd_epi32(cast!(a), cast!(b)))
-	}
-
 	/// See [_mm_hadds_epi16].
 	///
 	/// [_mm_hadds_epi16]: core::arch::x86_64::_mm_hadds_epi16
@@ -928,38 +562,6 @@ impl V2 {
 	#[inline(always)]
 	pub fn horizontal_saturating_sub_pack_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
 		cast!(self.ssse3._mm_hsubs_epi16(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hsub_ps].
-	///
-	/// [_mm_hsub_ps]: core::arch::x86_64::_mm_hsub_ps
-	#[inline(always)]
-	pub fn horizontal_sub_pack_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse3._mm_hsub_ps(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hsub_pd].
-	///
-	/// [_mm_hsub_pd]: core::arch::x86_64::_mm_hsub_pd
-	#[inline(always)]
-	pub fn horizontal_sub_pack_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse3._mm_hsub_pd(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hsub_epi16].
-	///
-	/// [_mm_hsub_epi16]: core::arch::x86_64::_mm_hsub_epi16
-	#[inline(always)]
-	pub fn horizontal_sub_pack_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.ssse3._mm_hsub_epi16(cast!(a), cast!(b)))
-	}
-
-	/// See [_mm_hsub_epi32].
-	///
-	/// [_mm_hsub_epi32]: core::arch::x86_64::_mm_hsub_epi32
-	#[inline(always)]
-	pub fn horizontal_sub_pack_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.ssse3._mm_hsub_epi32(cast!(a), cast!(b)))
 	}
 
 	/// Checks if the elements in each lane of `a` are NaN.
@@ -984,114 +586,6 @@ impl V2 {
 	#[inline(always)]
 	pub fn is_not_nan_f64x2(self, a: f64x2) -> m64x2 {
 		cast!(self.sse2._mm_cmpord_pd(cast!(a), cast!(a)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_max_ps(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_max_pd(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_max_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse4_1._mm_max_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse4_1._mm_max_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse4_1._mm_max_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse4_1._mm_max_epu32(cast!(a), cast!(b)))
-	}
-
-	/// Computes `max(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn max_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_max_epu8(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_min_ps(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_min_pd(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_min_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse4_1._mm_min_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse4_1._mm_min_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse4_1._mm_min_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse4_1._mm_min_epu32(cast!(a), cast!(b)))
-	}
-
-	/// Computes `min(a, b)`. for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn min_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_min_epu8(cast!(a), cast!(b)))
-	}
-
-	/// Computes `a * b` for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn mul_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_mul_ps(cast!(a), cast!(b)))
-	}
-
-	/// Computes `a * b` for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn mul_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_mul_pd(cast!(a), cast!(b)))
 	}
 
 	/// See [_mm_maddubs_epi16].
@@ -1192,90 +686,6 @@ impl V2 {
 	#[inline(always)]
 	pub fn not_u8x16(self, a: u8x16) -> u8x16 {
 		self.xor_u8x16(a, self.splat_u8x16(!0))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_or_ps(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_or_pd(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_m16x8(self, a: m16x8, b: m16x8) -> m16x8 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_m32x4(self, a: m32x4, b: m32x4) -> m32x4 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_m64x2(self, a: m64x2, b: m64x2) -> m64x2 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_m8x16(self, a: m8x16, b: m8x16) -> m8x16 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
-	}
-
-	/// Returns `a | b` for each bit in `a` and `b`.
-	#[inline(always)]
-	pub fn or_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_or_si128(cast!(a), cast!(b)))
 	}
 
 	/// See [_mm_packs_epi16].
@@ -1457,54 +867,6 @@ impl V2 {
 	pub fn round_f64x2(self, a: f64x2) -> f64x2 {
 		const ROUNDING: i32 = _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC;
 		cast!(self.sse4_1._mm_round_pd::<ROUNDING>(cast!(a)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_adds_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_adds_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_adds_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_adds_epu8(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_subs_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_subs_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_subs_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_subs_epu8(cast!(a), cast!(b)))
 	}
 
 	/// Combines `if_true` and `if_false`, selecting elements from `if_true` if the corresponding
@@ -1908,30 +1270,6 @@ impl V2 {
 		cast!(self.sse2._mm_sqrt_pd(cast!(a)))
 	}
 
-	/// Calculates `a - b` for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn sub_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_sub_ps(cast!(a), cast!(b)))
-	}
-
-	/// Calculates `a - b` for each lane in `a` and `b`.
-	#[inline(always)]
-	pub fn sub_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_sub_pd(cast!(a), cast!(b)))
-	}
-
-	/// Alternatively subtracts and adds the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn subadd_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse3._mm_addsub_ps(cast!(a), cast!(b)))
-	}
-
-	/// Alternatively subtracts and adds the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn subadd_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse3._mm_addsub_pd(cast!(a), cast!(b)))
-	}
-
 	/// See [_mm_sad_epu8].
 	///
 	/// [_mm_sad_epu8]: core::arch::x86_64::_mm_sad_epu8
@@ -1952,24 +1290,6 @@ impl V2 {
 	pub fn truncate_f64x2(self, a: f64x2) -> f64x2 {
 		const ROUNDING: i32 = _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC;
 		cast!(self.sse4_1._mm_round_pd::<ROUNDING>(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i16x8(self, a: i16x8) -> u16x8 {
-		cast!(self.ssse3._mm_abs_epi16(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i32x4(self, a: i32x4) -> u32x4 {
-		cast!(self.ssse3._mm_abs_epi32(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i8x16(self, a: i8x16) -> u8x16 {
-		cast!(self.ssse3._mm_abs_epi8(cast!(a)))
 	}
 
 	/// Multiplies the elements of each lane of `a` and `b`, and returns separately the low and
@@ -2051,208 +1371,561 @@ impl V2 {
 
 		(cast!(ab_lo), cast!(ab_hi))
 	}
+}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_add_epi16(cast!(a), cast!(b)))
+macro_rules! impl_simd_binop {
+	($func: ident, $op: ident, $ty: ident, $out: ty, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<$func _ $ty s>](self, a: Self::[<$ty s>], b: Self::[<$ty s>]) -> Self::[<$out s>] {
+				self.[<$op _ $ty x $factor>](a, b)
+			}
+		}
+	};
+	($func: ident, $op: ident, $($ty: ident x $factor: literal => $out: ty),*) => {
+		$(impl_simd_binop!($func, $op, $ty, $out, $factor);)*
+	};
+	($func: ident, $op: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_binop!($func, $op, $ty, $ty, $factor);)*
+	};
+	($func: ident, $($ty: ident x $factor: literal => $out: ty),*) => {
+		$(impl_simd_binop!($func, $func, $ty, $out, $factor);)*
+	};
+	($func: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_binop!($func, $func, $ty, $ty, $factor);)*
+	};
+}
+
+macro_rules! impl_simd_unop {
+	($func: ident, $op: ident, $ty: ident, $out: ty, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<$func _ $ty s>](self, a: Self::[<$ty s>]) -> Self::[<$out s>] {
+				self.[<$op _ $ty x $factor>](a)
+			}
+		}
+	};
+	($func: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_unop!($func, $func, $ty, $ty, $factor);)*
+	};
+}
+
+macro_rules! impl_scalar_binop {
+	($func: ident, $ty: ident, $out: ty, impl) => {
+		paste! {
+			#[inline(always)]
+			fn [<$func _ $ty s>](self, a: Self::[<$ty s>], b: Self::[<$ty s>]) -> Self::[<$out s>] {
+				Scalar128b.[<$func _ $ty s>](a, b)
+			}
+		}
+	};
+	($func: ident, $($ty: ident => $out: ty),*) => {
+		$(impl_scalar_binop!($func, $ty, $out, impl);)*
+	};
+	($func: ident, $($ty: ident),*) => {
+		$(impl_scalar_binop!($func, $ty, $ty, impl);)*
+	};
+}
+
+macro_rules! splat {
+	($ty: ty, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<splat_ $ty s>](self, value: $ty) -> Self::[<$ty s>] {
+				self.[<splat_ $ty x $factor>](value)
+			}
+		}
+	};
+	($($ty: ident x $factor: literal),*) => {
+		$(splat!($ty, $factor);)*
+	};
+}
+
+impl Simd for V2 {
+	type c32s = f32x4;
+	type c64s = f64x2;
+	type f32s = f32x4;
+	type f64s = f64x2;
+	type i16s = i16x8;
+	type i32s = i32x4;
+	type i64s = i64x2;
+	type i8s = i8x16;
+	type m16s = m16x8;
+	type m32s = m32x4;
+	type m64s = m64x2;
+	type m8s = m8x16;
+	type u16s = u16x8;
+	type u32s = u32x4;
+	type u64s = u64x2;
+	type u8s = u8x16;
+
+	const REGISTER_COUNT: usize = 16;
+
+	impl_simd_binop!(add, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(add, wrapping_add, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, u64 x 2, i64 x 2);
+
+	impl_simd_binop!(sub, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(sub, wrapping_sub, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, u64 x 2, i64 x 2);
+
+	impl_simd_binop!(mul, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(mul, wrapping_mul, u16 x 8, i16 x 8, u32 x 4, i32 x 4);
+
+	impl_scalar_binop!(mul, u64, i64, c32, c64);
+
+	impl_simd_binop!(and, m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(or, m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(xor, m8 x 16, u8 x 16, i8 x 16, m16 x 8, u16 x 8, i16 x 8, m32 x 4, u32 x 4, i32 x 4, m64 x 2, u64 x 2, i64 x 2, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(div, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(equal, cmp_eq, u8 x 16 => m8, u16 x 8 => m16, u32 x 4 => m32, u64 x 2 => m64, f32 x 4 => m32, f64 x 2 => m64);
+
+	impl_simd_binop!(greater_than, cmp_gt, u8 x 16 => m8, i8 x 16 => m8, u16 x 8 => m16, i16 x 8 => m16, u32 x 4 => m32, i32 x 4 => m32, u64 x 2 => m64, i64 x 2 => m64, f32 x 4 => m32, f64 x 2 => m64);
+
+	impl_simd_binop!(greater_than_or_equal, cmp_ge, u8 x 16 => m8, i8 x 16 => m8, u16 x 8 => m16, i16 x 8 => m16, u32 x 4 => m32, i32 x 4 => m32, u64 x 2 => m64, i64 x 2 => m64, f32 x 4 => m32, f64 x 2 => m64);
+
+	impl_simd_binop!(less_than, cmp_lt, u8 x 16 => m8, i8 x 16 => m8, u16 x 8 => m16, i16 x 8 => m16, u32 x 4 => m32, i32 x 4 => m32, u64 x 2 => m64, i64 x 2 => m64, f32 x 4 => m32, f64 x 2 => m64);
+
+	impl_simd_binop!(less_than_or_equal, cmp_le, u8 x 16 => m8, i8 x 16 => m8, u16 x 8 => m16, i16 x 8 => m16, u32 x 4 => m32, i32 x 4 => m32, u64 x 2 => m64, i64 x 2 => m64, f32 x 4 => m32, f64 x 2 => m64);
+
+	impl_scalar_binop!(conj_mul, c32, c64);
+
+	splat!(u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, u64 x 2, i64 x 2, f32 x 4, f64 x 2);
+
+	impl_simd_binop!(max, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, f64 x 2);
+
+	impl_scalar_binop!(max, u64, i64);
+
+	impl_simd_binop!(min, u8 x 16, i8 x 16, u16 x 8, i16 x 8, u32 x 4, i32 x 4, f32 x 4, f64 x 2);
+
+	impl_scalar_binop!(min, u64, i64);
+
+	impl_simd_unop!(not, m8 x 16, u8 x 16, m16 x 8, u16 x 8, m32 x 4, u32 x 4, m64 x 2, u64 x 2);
+
+	fn abs2_c32s(self, a: Self::c32s) -> Self::c32s {
+		let sqr = self.mul_f32s(a, a);
+		let sqr_rev = self
+			.sse
+			._mm_shuffle_ps::<0b10_11_00_01>(cast!(sqr), cast!(sqr));
+		self.add_f32s(sqr, cast!(sqr_rev))
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse2._mm_add_epi32(cast!(a), cast!(b)))
+	fn abs2_c64s(self, a: Self::c64s) -> Self::c64s {
+		let sqr = self.mul_f64s(a, a);
+		let sqr_rev = self.sse2._mm_shuffle_pd::<0b0101>(cast!(sqr), cast!(sqr));
+		self.add_f64s(sqr, cast!(sqr_rev))
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.sse2._mm_add_epi64(cast!(a), cast!(b)))
+	fn abs_max_c32s(self, a: Self::c32s) -> Self::c32s {
+		let max = self.abs_f32s(a);
+		let max_rev = self.sse._mm_shuffle_ps::<0b10_11_00_01>(cast!(a), cast!(a));
+		self.max_f32s(max, cast!(max_rev))
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_add_epi8(cast!(a), cast!(b)))
+	fn abs_max_c64s(self, a: Self::c64s) -> Self::c64s {
+		let max = self.abs_f64s(a);
+		let max_rev = self.sse2._mm_shuffle_pd::<0b0101>(cast!(max), cast!(max));
+		self.max_f64s(max, cast!(max_rev))
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_add_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_add_epi16(cast!(a), cast!(b)))
+	fn add_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
+		self.add_f32s(a, b)
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_add_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse2._mm_add_epi32(cast!(a), cast!(b)))
+	fn add_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::c64s {
+		self.add_f64s(a, b)
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_add_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.sse2._mm_add_epi64(cast!(a), cast!(b)))
+	fn equal_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::m32s {
+		self.equal_f32s(a, b)
 	}
 
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_add_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_add_epi8(cast!(a), cast!(b)))
+	fn equal_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::m64s {
+		self.equal_f64s(a, b)
 	}
 
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_mul_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_mullo_epi16(cast!(a), cast!(b)))
+	fn conj_c32s(self, a: Self::c32s) -> Self::c32s {
+		self.xor_f32s(a, self.splat_c32s(c32 { re: 0.0, im: -0.0 }))
 	}
 
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_mul_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse4_1._mm_mullo_epi32(cast!(a), cast!(b)))
+	fn conj_c64s(self, a: Self::c64s) -> Self::c64s {
+		self.xor_f64s(a, self.splat_c64s(c64 { re: 0.0, im: -0.0 }))
 	}
 
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_mul_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_mullo_epi16(cast!(a), cast!(b)))
+	fn conj_mul_add_c32s(self, a: Self::c32s, b: Self::c32s, c: Self::c32s) -> Self::c32s {
+		Scalar128b.conj_mul_add_c32s(a, b, c)
 	}
 
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
 	#[inline(always)]
-	pub fn wrapping_mul_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse4_1._mm_mullo_epi32(cast!(a), cast!(b)))
+	fn conj_mul_add_c64s(self, a: Self::c64s, b: Self::c64s, c: Self::c64s) -> Self::c64s {
+		Scalar128b.conj_mul_add_c64s(a, b, c)
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_sub_epi16(cast!(a), cast!(b)))
+	unsafe fn mask_load_ptr_c32s(self, mask: MemMask<Self::m32s>, ptr: *const c32) -> Self::c32s {
+		cast!(self.mask_load_ptr_u32s(mask, ptr as _))
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse2._mm_sub_epi32(cast!(a), cast!(b)))
+	unsafe fn mask_load_ptr_c64s(self, mask: MemMask<Self::m64s>, ptr: *const c64) -> Self::c64s {
+		cast!(self.mask_load_ptr_u64s(mask, ptr as _))
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.sse2._mm_sub_epi64(cast!(a), cast!(b)))
+	unsafe fn mask_load_ptr_u8s(self, mask: MemMask<Self::m8s>, ptr: *const u8) -> Self::u8s {
+		Scalar128b.mask_load_ptr_u8s(mask, ptr)
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_sub_epi8(cast!(a), cast!(b)))
+	unsafe fn mask_load_ptr_u16s(self, mask: MemMask<Self::m16s>, ptr: *const u16) -> Self::u16s {
+		Scalar128b.mask_load_ptr_u16s(mask, ptr)
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_sub_epi16(cast!(a), cast!(b)))
+	unsafe fn mask_load_ptr_u32s(self, mask: MemMask<Self::m32s>, ptr: *const u32) -> Self::u32s {
+		Scalar128b.mask_load_ptr_u32s(mask, ptr)
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse2._mm_sub_epi32(cast!(a), cast!(b)))
+	unsafe fn mask_load_ptr_u64s(self, mask: MemMask<Self::m64s>, ptr: *const u64) -> Self::u64s {
+		cast!(self.mask_load_ptr_u32s(
+			MemMask {
+				mask: cast!(mask.mask),
+				load: mask.load,
+				store: mask.store
+			},
+			ptr as _
+		))
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.sse2._mm_sub_epi64(cast!(a), cast!(b)))
+	unsafe fn mask_store_ptr_c32s(
+		self,
+		mask: MemMask<Self::m32s>,
+		ptr: *mut c32,
+		values: Self::c32s,
+	) {
+		self.mask_store_ptr_u32s(mask, ptr as _, cast!(values))
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn wrapping_sub_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_sub_epi8(cast!(a), cast!(b)))
+	unsafe fn mask_store_ptr_c64s(
+		self,
+		mask: MemMask<Self::m64s>,
+		ptr: *mut c64,
+		values: Self::c64s,
+	) {
+		self.mask_store_ptr_u64s(mask, ptr as _, cast!(values))
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn xor_f32x4(self, a: f32x4, b: f32x4) -> f32x4 {
-		cast!(self.sse._mm_xor_ps(cast!(a), cast!(b)))
+	unsafe fn mask_store_ptr_u8s(self, mask: MemMask<Self::m8s>, ptr: *mut u8, values: Self::u8s) {
+		Scalar128b.mask_store_ptr_u8s(mask, ptr, values);
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn xor_f64x2(self, a: f64x2, b: f64x2) -> f64x2 {
-		cast!(self.sse2._mm_xor_pd(cast!(a), cast!(b)))
+	unsafe fn mask_store_ptr_u16s(
+		self,
+		mask: MemMask<Self::m16s>,
+		ptr: *mut u16,
+		values: Self::u16s,
+	) {
+		Scalar128b.mask_store_ptr_u16s(mask, ptr, values);
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn xor_i16x8(self, a: i16x8, b: i16x8) -> i16x8 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	unsafe fn mask_store_ptr_u32s(
+		self,
+		mask: MemMask<Self::m32s>,
+		ptr: *mut u32,
+		values: Self::u32s,
+	) {
+		Scalar128b.mask_store_ptr_u32s(mask, ptr, values);
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
 	#[inline(always)]
-	pub fn xor_i32x4(self, a: i32x4, b: i32x4) -> i32x4 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	unsafe fn mask_store_ptr_u64s(
+		self,
+		mask: MemMask<Self::m64s>,
+		ptr: *mut u64,
+		values: Self::u64s,
+	) {
+		self.mask_store_ptr_u32s(
+			MemMask {
+				mask: cast!(mask.mask),
+				load: mask.load,
+				store: mask.store,
+			},
+			ptr as _,
+			cast!(values),
+		)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn mul_add_c32s(self, a: Self::c32s, b: Self::c32s, c: Self::c32s) -> Self::c32s {
+		Scalar128b.mul_add_c32s(a, b, c)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_i8x16(self, a: i8x16, b: i8x16) -> i8x16 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn mul_add_c64s(self, a: Self::c64s, b: Self::c64s, c: Self::c64s) -> Self::c64s {
+		Scalar128b.mul_add_c64s(a, b, c)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_m16x8(self, a: m16x8, b: m16x8) -> m16x8 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.mul_add_f32s(a, b, c)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_m32x4(self, a: m32x4, b: m32x4) -> m32x4 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.mul_add_f64s(a, b, c)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_m64x2(self, a: m64x2, b: m64x2) -> m64x2 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		Scalar128b.mul_add_f32s(a, b, c)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_m8x16(self, a: m8x16, b: m8x16) -> m8x16 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		Scalar128b.mul_add_f64s(a, b, c)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_u16x8(self, a: u16x8, b: u16x8) -> u16x8 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn neg_c32s(self, a: Self::c32s) -> Self::c32s {
+		self.xor_f32s(a, self.splat_f32s(-0.0))
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_u32x4(self, a: u32x4, b: u32x4) -> u32x4 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn neg_c64s(self, a: Self::c64s) -> Self::c64s {
+		self.xor_f64s(a, self.splat_f64s(-0.0))
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn reduce_max_c32s(self, a: Self::c32s) -> c32 {
+		self.reduce_max_c32x2(a)
 	}
 
-	/// Returns `a ^ b` for each bit in `a` and `b`.
 	#[inline(always)]
-	pub fn xor_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
-		cast!(self.sse2._mm_xor_si128(cast!(a), cast!(b)))
+	fn reduce_max_c64s(self, a: Self::c64s) -> c64 {
+		self.reduce_max_c64x1(a)
+	}
+
+	#[inline(always)]
+	fn reduce_max_f32s(self, a: Self::f32s) -> f32 {
+		self.reduce_max_f32x4(a)
+	}
+
+	#[inline(always)]
+	fn reduce_max_f64s(self, a: Self::f64s) -> f64 {
+		self.reduce_max_f64x2(a)
+	}
+
+	#[inline(always)]
+	fn reduce_min_c32s(self, a: Self::c32s) -> c32 {
+		self.reduce_min_c32x2(a)
+	}
+
+	#[inline(always)]
+	fn reduce_min_c64s(self, a: Self::c64s) -> c64 {
+		self.reduce_min_c64x1(a)
+	}
+
+	#[inline(always)]
+	fn reduce_min_f32s(self, a: Self::f32s) -> f32 {
+		self.reduce_min_f32x4(a)
+	}
+
+	#[inline(always)]
+	fn reduce_min_f64s(self, a: Self::f64s) -> f64 {
+		self.reduce_min_f64x2(a)
+	}
+
+	#[inline(always)]
+	fn reduce_product_f32s(self, a: Self::f32s) -> f32 {
+		self.reduce_product_f32x4(a)
+	}
+
+	#[inline(always)]
+	fn reduce_product_f64s(self, a: Self::f64s) -> f64 {
+		self.reduce_product_f64x2(a)
+	}
+
+	#[inline(always)]
+	fn reduce_sum_c32s(self, a: Self::c32s) -> c32 {
+		self.reduce_sum_c32x2(a)
+	}
+
+	#[inline(always)]
+	fn reduce_sum_c64s(self, a: Self::c64s) -> c64 {
+		self.reduce_sum_c64x1(a)
+	}
+
+	#[inline(always)]
+	fn reduce_sum_f32s(self, a: Self::f32s) -> f32 {
+		self.reduce_sum_f32x4(a)
+	}
+
+	#[inline(always)]
+	fn reduce_sum_f64s(self, a: Self::f64s) -> f64 {
+		self.reduce_sum_f64x2(a)
+	}
+
+	#[inline(always)]
+	fn rotate_right_c32s(self, a: Self::c32s, amount: usize) -> Self::c32s {
+		Scalar128b.rotate_right_c32s(a, amount)
+	}
+
+	#[inline(always)]
+	fn rotate_right_c64s(self, a: Self::c64s, amount: usize) -> Self::c64s {
+		Scalar128b.rotate_right_c64s(a, amount)
+	}
+
+	#[inline(always)]
+	fn rotate_right_u32s(self, a: Self::u32s, amount: usize) -> Self::u32s {
+		Scalar128b.rotate_right_u32s(a, amount)
+	}
+
+	#[inline(always)]
+	fn rotate_right_u64s(self, a: Self::u64s, amount: usize) -> Self::u64s {
+		Scalar128b.rotate_right_u64s(a, amount)
+	}
+
+	#[inline(always)]
+	fn select_u32s_m32s(
+		self,
+		mask: Self::m32s,
+		if_true: Self::u32s,
+		if_false: Self::u32s,
+	) -> Self::u32s {
+		let mask: __m128 = cast!(mask);
+		let if_true: __m128 = cast!(if_true);
+		let if_false: __m128 = cast!(if_false);
+
+		cast!(self.sse4_1._mm_blendv_ps(if_false, if_true, mask))
+	}
+
+	#[inline(always)]
+	fn select_u64s_m64s(
+		self,
+		mask: Self::m64s,
+		if_true: Self::u64s,
+		if_false: Self::u64s,
+	) -> Self::u64s {
+		let mask: __m128d = cast!(mask);
+		let if_true: __m128d = cast!(if_true);
+		let if_false: __m128d = cast!(if_false);
+
+		cast!(self.sse4_1._mm_blendv_pd(if_false, if_true, mask))
+	}
+
+	#[inline(always)]
+	fn splat_c32s(self, value: c32) -> Self::c32s {
+		cast!(self.splat_f64s(cast!(value)))
+	}
+
+	#[inline(always)]
+	fn splat_c64s(self, value: c64) -> Self::c64s {
+		Scalar128b.splat_c64s(value)
+	}
+
+	#[inline(always)]
+	fn sub_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
+		self.sub_f32s(a, b)
+	}
+
+	#[inline(always)]
+	fn sub_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::c64s {
+		self.sub_f64s(a, b)
+	}
+
+	#[inline(always)]
+	fn swap_re_im_c32s(self, a: Self::c32s) -> Self::c32s {
+		Scalar128b.swap_re_im_c32s(a)
+	}
+
+	#[inline(always)]
+	fn swap_re_im_c64s(self, a: Self::c64s) -> Self::c64s {
+		Scalar128b.swap_re_im_c64s(a)
+	}
+
+	#[inline(always)]
+	fn vectorize<Op: WithSimd>(self, op: Op) -> Op::Output {
+		struct Impl<Op> {
+			this: V2,
+			op: Op,
+		}
+		impl<Op: WithSimd> crate::NullaryFnOnce for Impl<Op> {
+			type Output = Op::Output;
+
+			#[inline(always)]
+			fn call(self) -> Self::Output {
+				self.op.with_simd(self.this)
+			}
+		}
+		self.vectorize(Impl { this: self, op })
+	}
+
+	#[inline(always)]
+	fn widening_mul_u32s(self, a: Self::u32s, b: Self::u32s) -> (Self::u32s, Self::u32s) {
+		self.widening_mul_u32x4(a, b)
+	}
+
+	#[inline(always)]
+	fn wrapping_dyn_shl_u32s(self, a: Self::u32s, amount: Self::u32s) -> Self::u32s {
+		Scalar128b.wrapping_dyn_shl_u32s(a, amount)
+	}
+
+	#[inline(always)]
+	fn wrapping_dyn_shr_u32s(self, a: Self::u32s, amount: Self::u32s) -> Self::u32s {
+		Scalar128b.wrapping_dyn_shr_u32s(a, amount)
 	}
 }

--- a/pulp/src/x86/v4.rs
+++ b/pulp/src/x86/v4.rs
@@ -142,19 +142,125 @@ static V4_U64_LAST_MASKS: [u8; 9] = [
 
 impl Seal for V4 {}
 
+macro_rules! splat {
+	($ty: ty, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<splat_ $ty s>](self, value: $ty) -> Self::[<$ty s>] {
+				self.[<splat_ $ty x $factor>](value)
+			}
+		}
+	};
+	($($ty: ident x $factor: literal),*) => {
+		$(splat!($ty, $factor);)*
+	};
+}
+
+macro_rules! impl_simd_binop {
+	($func: ident, $op: ident, $ty: ident, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<$func _ $ty s>](self, a: Self::[<$ty s>], b: Self::[<$ty s>]) -> Self::[<$ty s>] {
+				self.[<$op _ $ty x $factor>](a, b)
+			}
+		}
+	};
+	($func: ident, $op: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_binop!($func, $op, $ty, $factor);)*
+	};
+	($func: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_binop!($func, $func, $ty, $factor);)*
+	};
+}
+
+macro_rules! impl_simd_binop_mask {
+	($func: ident, $op: ident, $ty: ident, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<$func _ $ty s>](self, a: Self::[<$ty s>], b: Self::[<$ty s>]) -> [<b $factor>] {
+				self.[<$op _ $ty x $factor>](a, b)
+			}
+		}
+	};
+	($func: ident, $op: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_binop_mask!($func, $op, $ty, $factor);)*
+	};
+	($func: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_binop_mask!($func, $func, $ty, $factor);)*
+	};
+}
+
+macro_rules! impl_simd_unop {
+	($func: ident, $op: ident, $ty: ident, $out: ty, $factor: literal) => {
+		paste! {
+			#[inline(always)]
+			fn [<$func _ $ty s>](self, a: Self::[<$ty s>]) -> Self::[<$out s>] {
+				self.[<$op _ $ty x $factor>](a)
+			}
+		}
+	};
+	($func: ident, $($ty: ident x $factor: literal),*) => {
+		$(impl_simd_unop!($func, $func, $ty, $ty, $factor);)*
+	};
+}
+
 impl Simd for V4 {
 	type c32s = f32x16;
 	type c64s = f64x8;
 	type f32s = f32x16;
 	type f64s = f64x8;
+	type i16s = i16x32;
 	type i32s = i32x16;
 	type i64s = i64x8;
+	type i8s = i8x64;
+	type m16s = b32;
 	type m32s = b16;
 	type m64s = b8;
+	type m8s = b64;
+	type u16s = u16x32;
 	type u32s = u32x16;
 	type u64s = u64x8;
+	type u8s = u8x64;
 
 	const REGISTER_COUNT: usize = 32;
+
+	impl_simd_binop!(add, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(add, wrapping_add, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	impl_simd_binop!(sub, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(sub, wrapping_sub, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	impl_simd_binop!(mul, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(mul, wrapping_mul, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	impl_simd_binop!(and, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(or, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(xor, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(div, f32 x 16, f64 x 8);
+
+	impl_simd_binop_mask!(equal, cmp_eq, u8 x 64, u16 x 32, u32 x 16, u64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop_mask!(greater_than, cmp_gt, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop_mask!(greater_than_or_equal, cmp_ge, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop_mask!(less_than, cmp_lt, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop_mask!(less_than_or_equal, cmp_le, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	splat!(u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(max, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_binop!(min, u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	impl_simd_unop!(not, u8 x 64, u16 x 32, u32 x 16, u64 x 8);
 
 	#[inline(always)]
 	fn abs2_c32s(self, a: Self::c32s) -> Self::c32s {
@@ -203,23 +309,13 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
-	fn add_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s {
-		cast!(self.avx512f._mm512_add_ps(cast!(a), cast!(b)))
+	fn equal_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::m32s {
+		self.equal_f32s(a, b)
 	}
 
 	#[inline(always)]
-	fn add_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::f64s {
-		cast!(self.avx512f._mm512_add_pd(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn add_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::u32s {
-		cast!(self.avx512f._mm512_add_epi32(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn add_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::u64s {
-		cast!(self.avx512f._mm512_add_epi64(cast!(a), cast!(b)))
+	fn equal_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::m64s {
+		self.equal_f64s(a, b)
 	}
 
 	#[inline(always)]
@@ -230,16 +326,6 @@ impl Simd for V4 {
 	#[inline(always)]
 	fn and_m64s(self, a: Self::m64s, b: Self::m64s) -> Self::m64s {
 		b8(a.0 & b.0)
-	}
-
-	#[inline(always)]
-	fn and_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::u32s {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn and_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::u64s {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
 	}
 
 	#[inline(always)]
@@ -435,52 +521,6 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
-	fn div_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s {
-		cast!(self.avx512f._mm512_div_ps(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn div_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::f64s {
-		cast!(self.avx512f._mm512_div_pd(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn equal_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::m32s {
-		cast!(
-			self.avx512f
-				._mm512_cmp_ps_mask::<_CMP_EQ_OQ>(cast!(a), cast!(b))
-		)
-	}
-
-	#[inline(always)]
-	fn equal_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::m64s {
-		cast!(
-			self.avx512f
-				._mm512_cmp_pd_mask::<_CMP_EQ_OQ>(cast!(a), cast!(b))
-		)
-	}
-
-	#[inline(always)]
-	fn greater_than_or_equal_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::m32s {
-		self.cmp_ge_u32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn greater_than_or_equal_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::m64s {
-		self.cmp_ge_u64x8(a, b)
-	}
-
-	#[inline(always)]
-	fn greater_than_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::m32s {
-		self.cmp_gt_u32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn greater_than_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::m64s {
-		self.cmp_gt_u64x8(a, b)
-	}
-
-	#[inline(always)]
 	fn interleave_shfl_f32s<T: Interleave>(self, values: T) -> T {
 		if try_const! {
 			(core::mem::size_of::<T>() == 2 * core::mem::size_of::<Self::f32s>())
@@ -531,58 +571,6 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
-	fn less_than_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::m32s {
-		cast!(
-			self.avx512f
-				._mm512_cmp_ps_mask::<_CMP_LT_OQ>(cast!(a), cast!(b))
-		)
-	}
-
-	#[inline(always)]
-	fn less_than_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::m64s {
-		cast!(
-			self.avx512f
-				._mm512_cmp_pd_mask::<_CMP_LT_OQ>(cast!(a), cast!(b))
-		)
-	}
-
-	#[inline(always)]
-	fn less_than_or_equal_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::m32s {
-		cast!(
-			self.avx512f
-				._mm512_cmp_ps_mask::<_CMP_LE_OQ>(cast!(a), cast!(b))
-		)
-	}
-
-	#[inline(always)]
-	fn less_than_or_equal_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::m64s {
-		cast!(
-			self.avx512f
-				._mm512_cmp_pd_mask::<_CMP_LE_OQ>(cast!(a), cast!(b))
-		)
-	}
-
-	#[inline(always)]
-	fn less_than_or_equal_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::m32s {
-		self.cmp_le_u32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_or_equal_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::m64s {
-		self.cmp_le_u64x8(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::m32s {
-		self.cmp_lt_u32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::m64s {
-		self.cmp_lt_u64x8(a, b)
-	}
-
-	#[inline(always)]
 	fn mask_between_m32s(self, start: u32, end: u32) -> MemMask<Self::m32s> {
 		let start = start.min(16) as usize;
 		let end = end.min(16) as usize;
@@ -618,6 +606,31 @@ impl Simd for V4 {
 	#[inline(always)]
 	unsafe fn mask_load_ptr_c64s(self, mask: MemMask<Self::m64s>, ptr: *const c64) -> Self::c64s {
 		cast!(self.mask_load_ptr_u64s(mask, ptr as _))
+	}
+
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
+	#[inline(always)]
+	unsafe fn mask_load_ptr_u8s(self, mask: MemMask<Self::m8s>, ptr: *const u8) -> Self::u8s {
+		match mask.load {
+			Some(load) => cast!(avx512_ld_u32s(ptr as _, load)),
+			None => cast!(self.avx512bw._mm512_maskz_loadu_epi8(mask.mask.0, ptr as _)),
+		}
+	}
+
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
+	#[inline(always)]
+	unsafe fn mask_load_ptr_u16s(self, mask: MemMask<Self::m16s>, ptr: *const u16) -> Self::u16s {
+		match mask.load {
+			Some(load) => cast!(avx512_ld_u32s(ptr as _, load)),
+			None => cast!(
+				self.avx512bw
+					._mm512_maskz_loadu_epi16(mask.mask.0, ptr as _)
+			),
+		}
 	}
 
 	/// # Safety
@@ -672,6 +685,39 @@ impl Simd for V4 {
 	///
 	/// See the trait-level safety documentation.
 	#[inline(always)]
+	unsafe fn mask_store_ptr_u8s(self, mask: MemMask<Self::m8s>, ptr: *mut u8, values: Self::u8s) {
+		match mask.store {
+			Some(store) => avx512_st_u32s(ptr as _, cast!(values), store),
+			None => {
+				self.avx512bw
+					._mm512_mask_storeu_epi8(ptr as *mut _, mask.mask.0, cast!(values))
+			},
+		}
+	}
+
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
+	#[inline(always)]
+	unsafe fn mask_store_ptr_u16s(
+		self,
+		mask: MemMask<Self::m16s>,
+		ptr: *mut u16,
+		values: Self::u16s,
+	) {
+		match mask.store {
+			Some(store) => avx512_st_u32s(ptr as _, cast!(values), store),
+			None => {
+				self.avx512bw
+					._mm512_mask_storeu_epi16(ptr as *mut _, mask.mask.0, cast!(values))
+			},
+		}
+	}
+
+	/// # Safety
+	///
+	/// See the trait-level safety documentation.
+	#[inline(always)]
 	unsafe fn mask_store_ptr_u32s(
 		self,
 		mask: MemMask<Self::m32s>,
@@ -704,26 +750,6 @@ impl Simd for V4 {
 					._mm512_mask_storeu_epi64(ptr as *mut _, mask.mask.0, cast!(values))
 			},
 		}
-	}
-
-	#[inline(always)]
-	fn max_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s {
-		cast!(self.avx512f._mm512_max_ps(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn max_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::f64s {
-		cast!(self.avx512f._mm512_max_pd(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn min_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s {
-		cast!(self.avx512f._mm512_min_ps(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn min_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::f64s {
-		cast!(self.avx512f._mm512_min_pd(cast!(a), cast!(b)))
 	}
 
 	#[inline(always)]
@@ -809,16 +835,6 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
-	fn mul_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s {
-		cast!(self.avx512f._mm512_mul_ps(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn mul_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::f64s {
-		cast!(self.avx512f._mm512_mul_pd(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
 	fn neg_c32s(self, a: Self::c32s) -> Self::c32s {
 		self.xor_f32s(a, self.splat_f32s(-0.0))
 	}
@@ -826,6 +842,16 @@ impl Simd for V4 {
 	#[inline(always)]
 	fn neg_c64s(self, a: Self::c64s) -> Self::c64s {
 		self.xor_f64s(a, self.splat_f64s(-0.0))
+	}
+
+	#[inline(always)]
+	fn not_m8s(self, a: Self::m8s) -> Self::m8s {
+		b64(!a.0)
+	}
+
+	#[inline(always)]
+	fn not_m16s(self, a: Self::m16s) -> Self::m16s {
+		b32(!a.0)
 	}
 
 	#[inline(always)]
@@ -839,22 +865,6 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
-	fn not_u32s(self, a: Self::u32s) -> Self::u32s {
-		cast!(
-			self.avx512f
-				._mm512_xor_si512(self.avx512f._mm512_set1_epi32(-1), cast!(a))
-		)
-	}
-
-	#[inline(always)]
-	fn not_u64s(self, a: Self::u64s) -> Self::u64s {
-		cast!(
-			self.avx512f
-				._mm512_xor_si512(self.avx512f._mm512_set1_epi32(-1), cast!(a))
-		)
-	}
-
-	#[inline(always)]
 	fn or_m32s(self, a: Self::m32s, b: Self::m32s) -> Self::m32s {
 		b16(a.0 | b.0)
 	}
@@ -862,16 +872,6 @@ impl Simd for V4 {
 	#[inline(always)]
 	fn or_m64s(self, a: Self::m64s, b: Self::m64s) -> Self::m64s {
 		b8(a.0 | b.0)
-	}
-
-	#[inline(always)]
-	fn or_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::u32s {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn or_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::u64s {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
 	}
 
 	#[inline(always)]
@@ -1105,26 +1105,6 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
-	fn splat_f32s(self, value: f32) -> Self::f32s {
-		cast!(self.avx512f._mm512_set1_ps(value))
-	}
-
-	#[inline(always)]
-	fn splat_f64s(self, value: f64) -> Self::f64s {
-		cast!(self.avx512f._mm512_set1_pd(value))
-	}
-
-	#[inline(always)]
-	fn splat_u32s(self, value: u32) -> Self::u32s {
-		cast!(self.avx512f._mm512_set1_epi32(value as i32))
-	}
-
-	#[inline(always)]
-	fn splat_u64s(self, value: u64) -> Self::u64s {
-		cast!(self.avx512f._mm512_set1_epi64(value as i64))
-	}
-
-	#[inline(always)]
 	fn sub_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
 		self.sub_f32s(a, b)
 	}
@@ -1132,26 +1112,6 @@ impl Simd for V4 {
 	#[inline(always)]
 	fn sub_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::c64s {
 		self.sub_f64s(a, b)
-	}
-
-	#[inline(always)]
-	fn sub_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s {
-		cast!(self.avx512f._mm512_sub_ps(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn sub_f64s(self, a: Self::f64s, b: Self::f64s) -> Self::f64s {
-		cast!(self.avx512f._mm512_sub_pd(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn sub_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::u32s {
-		cast!(self.avx512f._mm512_sub_epi32(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn sub_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::u64s {
-		cast!(self.avx512f._mm512_sub_epi64(cast!(a), cast!(b)))
 	}
 
 	#[inline(always)]
@@ -1205,59 +1165,81 @@ impl Simd for V4 {
 	fn xor_m64s(self, a: Self::m64s, b: Self::m64s) -> Self::m64s {
 		b8(a.0 ^ b.0)
 	}
-
-	#[inline(always)]
-	fn xor_u32s(self, a: Self::u32s, b: Self::u32s) -> Self::u32s {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn xor_u64s(self, a: Self::u64s, b: Self::u64s) -> Self::u64s {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	#[inline(always)]
-	fn greater_than_or_equal_i32s(self, a: Self::i32s, b: Self::i32s) -> Self::m32s {
-		self.cmp_ge_i32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn greater_than_or_equal_i64s(self, a: Self::i64s, b: Self::i64s) -> Self::m64s {
-		self.cmp_ge_i64x8(a, b)
-	}
-
-	#[inline(always)]
-	fn greater_than_i32s(self, a: Self::i32s, b: Self::i32s) -> Self::m32s {
-		self.cmp_gt_i32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn greater_than_i64s(self, a: Self::i64s, b: Self::i64s) -> Self::m64s {
-		self.cmp_gt_i64x8(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_or_equal_i32s(self, a: Self::i32s, b: Self::i32s) -> Self::m32s {
-		self.cmp_le_i32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_or_equal_i64s(self, a: Self::i64s, b: Self::i64s) -> Self::m64s {
-		self.cmp_le_i64x8(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_i32s(self, a: Self::i32s, b: Self::i32s) -> Self::m32s {
-		self.cmp_lt_i32x16(a, b)
-	}
-
-	#[inline(always)]
-	fn less_than_i64s(self, a: Self::i64s, b: Self::i64s) -> Self::m64s {
-		self.cmp_lt_i64x8(a, b)
-	}
 }
 
 impl V4 {
+	binop_512_nosign!(avx512f: add, "Adds the elements of each lane of `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_nosign!(avx512f: add, "Adds the elements of each lane of `a` and `b`, with wrapping on overflow.", wrapping_add, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	binop_512_nosign!(avx512bw: add, "Adds the elements of each lane of `a` and `b`, with wrapping on overflow.", wrapping_add, u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_512!(avx512dq: and, "Returns `a & b` for each bit in `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_full!(avx512f: and, "Returns `a & b` for each bit in `a` and `b`.", m8 x 64, u8 x 64, i8 x 64, m16 x 32, u16 x 32, i16 x 32, m32 x 16, u32 x 16, i32 x 16, m64 x 8, u64 x 8, i64 x 8);
+
+	binop_512!(avx512dq: andnot, "Returns `!a & b` for each bit in `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_full!(avx512f: andnot, "Returns `!a & b` for each bit in `a` and `b`.", m8 x 64, u8 x 64, i8 x 64, m16 x 32, u16 x 32, i16 x 32, m32 x 16, u32 x 16, i32 x 16, m64 x 8, u64 x 8, i64 x 8);
+
+	binop_512!(avx512bw: avg, "Computes `average(a, b)` for each lane of `a` and `b`.", average, u8 x 64, u16 x 32);
+
+	binop_512_nosign_mask!(avx512f: cmpeq, "Compares the elements in each lane of `a` and `b` for equality.", cmp_eq, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	binop_512_nosign_mask!(avx512bw: cmpeq, "Compares the elements in each lane of `a` and `b` for equality.", cmp_eq, u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_512_mask!(avx512f: cmpgt, "Compares the elements in each lane of `a` and `b` for equality.", cmp_gt, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	binop_512_mask!(avx512bw: cmpgt, "Compares the elements in each lane of `a` and `b` for equality.", cmp_gt, u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_512!(avx512f: div, "Divides the elements of each lane of `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_128!(avx512f: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", u64 x 2, i64 x 2);
+
+	binop_256!(avx512f: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", u64 x 4, i64 x 4);
+
+	binop_512!(avx512f: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	binop_512!(avx512bw: max, "Computes `max(a, b)`. for each lane in `a` and `b`.", u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_256!(avx512f: min, "Computes `min(a, b)`. for each lane in `a` and `b`.", u64 x 4, i64 x 4);
+
+	binop_512!(avx512f: min, "Computes `min(a, b)`. for each lane in `a` and `b`.", u32 x 16, i32 x 16, u64 x 8, i64 x 8, f32 x 16, f64 x 8);
+
+	binop_512!(avx512bw: min, "Computes `min(a, b)`. for each lane in `a` and `b`.", u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_512!(avx512f: mul, "Computes `a * b` for each lane in `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_nosign!(avx512f: mullo, "Computes `a * b` for each lane in `a` and `b`, with wrapping overflow.", wrapping_mul, u32 x 16, i32 x 16);
+
+	binop_512_nosign!(avx512bw: mullo, "Computes `a * b` for each lane in `a` and `b`, with wrapping overflow.", wrapping_mul, u16 x 32, i16 x 32);
+
+	binop_512_nosign!(avx512dq: mullo, "Computes `a * b` for each lane in `a` and `b`, with wrapping overflow.", wrapping_mul, u64 x 8, i64 x 8);
+
+	binop_512!(avx512dq: or, "Returns `a | b` for each bit in `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_full!(avx512f: or, "Returns `a | b` for each bit in `a` and `b`.", u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	binop_512!(avx512bw: adds, "Adds the elements of each lane of `a` and `b`, with saturation.", saturating_add, u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_512!(avx512bw: subs, "Subtracts the elements of each lane of `a` and `b`, with saturation.", saturating_sub, u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	binop_512_nosign!(avx512f: sub, "Subtracts the elements of each lane of `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_nosign!(avx512f: sub, "Subtracts the elements of each lane of `a` and `b`, with wrapping overflow.", wrapping_sub, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
+	binop_512_nosign!(avx512bw: sub, "Subtracts the elements of each lane of `a` and `b`, with wrapping overflow.", wrapping_sub, u8 x 64, i8 x 64, u16 x 32, i16 x 32);
+
+	unop_256!(avx512f: abs, "Computes the unsigned absolute value of the elements of each lane of `a`.", unsigned_abs, i64 x 4);
+
+	unop_512!(avx512f: abs, "Computes the unsigned absolute value of the elements of each lane of `a`.", unsigned_abs, i32 x 16, i64 x 8);
+
+	unop_512!(avx512bw: abs, "Computes the unsigned absolute value of the elements of each lane of `a`.", unsigned_abs, i8 x 64, i16 x 32);
+
+	binop_512!(avx512dq: xor, "Returns `a ^ b` for each bit in `a` and `b`.", f32 x 16, f64 x 8);
+
+	binop_512_full!(avx512f: xor, "Returns `a ^ b` for each bit in `a` and `b`.", u8 x 64, i8 x 64, u16 x 32, i16 x 32, u32 x 16, i32 x 16, u64 x 8, i64 x 8);
+
 	/// Computes the absolute value of the elements of each lane of `a`.
 	#[inline(always)]
 	pub fn abs_f32x16(self, a: f32x16) -> f32x16 {
@@ -1268,150 +1250,6 @@ impl V4 {
 	#[inline(always)]
 	pub fn abs_f64x8(self, a: f64x8) -> f64x8 {
 		cast!(self.avx512f._mm512_abs_pd(cast!(a)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn add_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_add_ps(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn add_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_add_pd(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of `a` and `b`.
-	#[inline(always)]
-	pub fn and_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512f._mm512_and_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise AND of NOT `a` and `b`.
-	#[inline(always)]
-	pub fn andnot_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512f._mm512_andnot_si512(cast!(a), cast!(b)))
-	}
-
-	/// Averages the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn average_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_avg_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Averages the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn average_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_avg_epu8(cast!(a), cast!(b)))
 	}
 
 	/// Rounds the elements of each lane of `a` to the nearest integer towards positive infinity.
@@ -1477,18 +1315,6 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for equality.
 	#[inline(always)]
-	pub fn cmp_eq_i16x32(self, a: i16x32, b: i16x32) -> b32 {
-		cast!(self.avx512bw._mm512_cmpeq_epi16_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_i32x16(self, a: i32x16, b: i32x16) -> b16 {
-		cast!(self.avx512f._mm512_cmpeq_epi32_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
 	pub fn cmp_eq_i32x8(self, a: i32x8, b: i32x8) -> b8 {
 		let simd = self.avx512f;
 		cast!(simd._mm256_cmpeq_epi32_mask(cast!(a), cast!(b)))
@@ -1503,12 +1329,6 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for equality.
 	#[inline(always)]
-	pub fn cmp_eq_i64x8(self, a: i64x8, b: i64x8) -> b8 {
-		cast!(self.avx512f._mm512_cmpeq_epi64_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
 	pub fn cmp_eq_i8x32(self, a: i8x32, b: i8x32) -> b32 {
 		let simd = self.avx512bw;
 		cast!(simd._mm256_cmpeq_epi8_mask(cast!(a), cast!(b)))
@@ -1516,27 +1336,9 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for equality.
 	#[inline(always)]
-	pub fn cmp_eq_i8x64(self, a: i8x64, b: i8x64) -> b64 {
-		cast!(self.avx512bw._mm512_cmpeq_epi8_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
 	pub fn cmp_eq_u16x16(self, a: u16x16, b: u16x16) -> b16 {
 		let simd = self.avx512bw;
 		cast!(simd._mm256_cmpeq_epi16_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u16x32(self, a: u16x32, b: u16x32) -> b32 {
-		cast!(self.avx512bw._mm512_cmpeq_epi16_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u32x16(self, a: u32x16, b: u32x16) -> b16 {
-		cast!(self.avx512f._mm512_cmpeq_epi32_mask(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for equality.
@@ -1555,21 +1357,9 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for equality.
 	#[inline(always)]
-	pub fn cmp_eq_u64x8(self, a: u64x8, b: u64x8) -> b8 {
-		cast!(self.avx512f._mm512_cmpeq_epi64_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
 	pub fn cmp_eq_u8x32(self, a: u8x32, b: u8x32) -> b32 {
 		let simd = self.avx512bw;
 		cast!(simd._mm256_cmpeq_epi8_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for equality.
-	#[inline(always)]
-	pub fn cmp_eq_u8x64(self, a: u8x64, b: u8x64) -> b64 {
-		cast!(self.avx512bw._mm512_cmpeq_epi8_mask(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than-or-equal-to.
@@ -1757,18 +1547,6 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than.
 	#[inline(always)]
-	pub fn cmp_gt_i16x32(self, a: i16x32, b: i16x32) -> b32 {
-		cast!(self.avx512bw._mm512_cmpgt_epi16_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_i32x16(self, a: i32x16, b: i32x16) -> b16 {
-		cast!(self.avx512f._mm512_cmpgt_epi32_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
 	pub fn cmp_gt_i32x8(self, a: i32x8, b: i32x8) -> b8 {
 		let simd = self.avx512f;
 		cast!(simd._mm256_cmpgt_epi32_mask(cast!(a), cast!(b)))
@@ -1783,12 +1561,6 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than.
 	#[inline(always)]
-	pub fn cmp_gt_i64x8(self, a: i64x8, b: i64x8) -> b8 {
-		cast!(self.avx512f._mm512_cmpgt_epi64_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
 	pub fn cmp_gt_i8x32(self, a: i8x32, b: i8x32) -> b32 {
 		let simd = self.avx512bw;
 		cast!(simd._mm256_cmpgt_epi8_mask(cast!(a), cast!(b)))
@@ -1796,27 +1568,9 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than.
 	#[inline(always)]
-	pub fn cmp_gt_i8x64(self, a: i8x64, b: i8x64) -> b64 {
-		cast!(self.avx512bw._mm512_cmpgt_epi8_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
 	pub fn cmp_gt_u16x16(self, a: u16x16, b: u16x16) -> b16 {
 		let simd = self.avx512bw;
 		cast!(simd._mm256_cmpgt_epu16_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_u16x32(self, a: u16x32, b: u16x32) -> b32 {
-		cast!(self.avx512bw._mm512_cmpgt_epu16_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_u32x16(self, a: u32x16, b: u32x16) -> b16 {
-		cast!(self.avx512f._mm512_cmpgt_epu32_mask(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than.
@@ -1835,21 +1589,9 @@ impl V4 {
 
 	/// Compares the elements in each lane of `a` and `b` for greater-than.
 	#[inline(always)]
-	pub fn cmp_gt_u64x8(self, a: u64x8, b: u64x8) -> b8 {
-		cast!(self.avx512f._mm512_cmpgt_epu64_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
 	pub fn cmp_gt_u8x32(self, a: u8x32, b: u8x32) -> b32 {
 		let simd = self.avx512bw;
 		cast!(simd._mm256_cmpgt_epu8_mask(cast!(a), cast!(b)))
-	}
-
-	/// Compares the elements in each lane of `a` and `b` for greater-than.
-	#[inline(always)]
-	pub fn cmp_gt_u8x64(self, a: u8x64, b: u8x64) -> b64 {
-		cast!(self.avx512bw._mm512_cmpgt_epu8_mask(cast!(a), cast!(b)))
 	}
 
 	/// Compares the elements in each lane of `a` and `b` for less-than-or-equal-to.
@@ -3080,18 +2822,6 @@ impl V4 {
 		cast!(a)
 	}
 
-	/// Divides the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn div_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_div_ps(cast!(a), cast!(b)))
-	}
-
-	/// Divides the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn div_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_div_pd(cast!(a), cast!(b)))
-	}
-
 	/// Rounds the elements of each lane of `a` to the nearest integer towards negative infinity.
 	#[inline(always)]
 	pub fn floor_f32x16(self, a: f32x16) -> f32x16 {
@@ -3182,166 +2912,10 @@ impl V4 {
 		)
 	}
 
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_max_ps(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_max_pd(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_max_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_max_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_i64x2(self, a: i64x2, b: i64x2) -> i64x2 {
-		cast!(self.avx512f._mm_max_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_i64x4(self, a: i64x4, b: i64x4) -> i64x4 {
-		cast!(self.avx512f._mm256_max_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_max_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512bw._mm512_max_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_max_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_max_epu32(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
-		cast!(self.avx512f._mm_max_epu64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_u64x4(self, a: u64x4, b: u64x4) -> u64x4 {
-		cast!(self.avx512f._mm256_max_epu64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_max_epu64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise maximum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn max_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_max_epu8(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_min_ps(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_min_pd(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_min_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_min_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_i64x4(self, a: i64x4, b: i64x4) -> i64x4 {
-		cast!(self.avx512f._mm256_min_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_min_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512bw._mm512_min_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_min_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_min_epu32(cast!(a), cast!(b)))
-	}
-
 	/// Computes the elementwise minimum of each lane of `a` and `b`.
 	#[inline(always)]
 	pub fn min_u64x2(self, a: u64x2, b: u64x2) -> u64x2 {
 		cast!(self.avx512f._mm_min_epu64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_u64x4(self, a: u64x4, b: u64x4) -> u64x4 {
-		cast!(self.avx512f._mm256_min_epu64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_min_epu64(cast!(a), cast!(b)))
-	}
-
-	/// Computes the elementwise minimum of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn min_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_min_epu8(cast!(a), cast!(b)))
 	}
 
 	/// Multiplies the elements in each lane of `a` and `b`, and adds the results to each lane of
@@ -3378,18 +2952,6 @@ impl V4 {
 			cast!(b),
 			cast!(self.sub_f64x8(self.splat_f64x8(-0.0), c)),
 		))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn mul_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_mul_ps(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn mul_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_mul_pd(cast!(a), cast!(b)))
 	}
 
 	/// Multiplies the elements in each lane of `a` and `b`, and subtracts each lane of `c` from
@@ -3514,66 +3076,6 @@ impl V4 {
 		self.xor_u8x64(a, self.splat_u8x64(!0))
 	}
 
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise OR of `a` and `b`.
-	#[inline(always)]
-	pub fn or_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512f._mm512_or_si512(cast!(a), cast!(b)))
-	}
-
 	/// See `_mm512_packs_epi16`
 	#[inline(always)]
 	pub fn pack_with_signed_saturation_i16x32(self, a: i16x32, b: i16x32) -> i8x64 {
@@ -3616,54 +3118,6 @@ impl V4 {
 			self.avx512f
 				._mm512_roundscale_pd::<_MM_FROUND_TO_NEAREST_INT>(cast!(a)),
 		)
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_adds_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512bw._mm512_adds_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_adds_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_add_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_adds_epu8(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_subs_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512bw._mm512_subs_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_subs_epu16(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with saturation.
-	#[inline(always)]
-	pub fn saturating_sub_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_subs_epu8(cast!(a), cast!(b)))
 	}
 
 	/// Combines `if_true` and `if_false`, selecting elements from `if_true` if the corresponding
@@ -4342,18 +3796,6 @@ impl V4 {
 		cast!(self.avx512f._mm512_sqrt_pd(cast!(a)))
 	}
 
-	/// Subtracts the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn sub_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_sub_ps(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`.
-	#[inline(always)]
-	pub fn sub_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_sub_pd(cast!(a), cast!(b)))
-	}
-
 	/// See `_mm512_sad_epu8`
 	#[inline(always)]
 	pub fn sum_of_absolute_differences_u8x64(self, a: u8x64, b: u8x64) -> u64x8 {
@@ -4376,36 +3818,6 @@ impl V4 {
 			self.avx512f
 				._mm512_roundscale_pd::<_MM_FROUND_TO_ZERO>(cast!(a)),
 		)
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i16x32(self, a: i16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_abs_epi16(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i32x16(self, a: i32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_abs_epi32(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i64x4(self, a: i64x4) -> u64x4 {
-		cast!(self.avx512f._mm256_abs_epi64(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i64x8(self, a: i64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_abs_epi64(cast!(a)))
-	}
-
-	/// Computes the unsigned absolute value of the elements of each lane of `a`.
-	#[inline(always)]
-	pub fn unsigned_abs_i8x64(self, a: i8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_abs_epi8(cast!(a)))
 	}
 
 	/// Multiplies the elements of each lane of `a` and `b`, and returns separately the low and
@@ -4494,198 +3906,6 @@ impl V4 {
 		);
 
 		(cast!(ab_lo), cast!(ab_hi))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_add_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_add_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_add_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512bw._mm512_add_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_add_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_add_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_add_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Adds the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_add_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_add_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_mul_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_mullo_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_mul_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_mullo_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_mul_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_mullox_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_mul_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_mullo_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_mul_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_mullo_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Multiplies the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_mul_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_mullox_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512bw._mm512_sub_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_sub_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_sub_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512bw._mm512_sub_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512bw._mm512_sub_epi16(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_sub_epi32(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_sub_epi64(cast!(a), cast!(b)))
-	}
-
-	/// Subtracts the elements of each lane of `a` and `b`, with wrapping on overflow.
-	#[inline(always)]
-	pub fn wrapping_sub_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512bw._mm512_sub_epi8(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_f32x16(self, a: f32x16, b: f32x16) -> f32x16 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_f64x8(self, a: f64x8, b: f64x8) -> f64x8 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_i16x32(self, a: i16x32, b: i16x32) -> i16x32 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_i32x16(self, a: i32x16, b: i32x16) -> i32x16 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_i64x8(self, a: i64x8, b: i64x8) -> i64x8 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_i8x64(self, a: i8x64, b: i8x64) -> i8x64 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_u16x32(self, a: u16x32, b: u16x32) -> u16x32 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_u32x16(self, a: u32x16, b: u32x16) -> u32x16 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_u64x8(self, a: u64x8, b: u64x8) -> u64x8 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
-	}
-
-	/// Returns the bitwise XOR of `a` and `b`.
-	#[inline(always)]
-	pub fn xor_u8x64(self, a: u8x64, b: u8x64) -> u8x64 {
-		cast!(self.avx512f._mm512_xor_si512(cast!(a), cast!(b)))
 	}
 }
 


### PR DESCRIPTION
I needed support for 8/16 bit types and min/max for integers, but the changes quickly became unmanageable. So instead I tried reining in the code duplication a bit using some [`paste`](https://docs.rs/paste/latest/paste/) macros so it's easier to add more types to existing operations, or add more simple ops. I managed to add a lot of new type support while shrinking code size, and I used cargo-semver-checks to ensure no breaking changes were added.

One thing I'm unsure about are the 8 and 16 bit masked loads - there are several approaches to solving this without AVX-512, but they each have performance tradeoffs. So for the time being, I have them fall back to the scalar implementation on all targets except V4.