### PR TITLE
fix mismatched miri types

### DIFF
--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -2255,8 +2255,8 @@ unsafe fn vfmaq_f64(c: float64x2_t, a: float64x2_t, b: float64x2_t) -> float64x2
 	let b: f64x2 = cast!(b);
 
 	cast!(f64x2(
-		crate::fma_f32(a.0, b.0, c.0),
-		crate::fma_f32(a.1, b.1, c.1),
+		crate::fma_f64(a.0, b.0, c.0),
+		crate::fma_f64(a.1, b.1, c.1),
 	))
 }
 
@@ -2267,10 +2267,10 @@ unsafe fn vfmaq_f32(c: float32x4_t, a: float32x4_t, b: float32x4_t) -> float32x4
 	let b: f32x4 = cast!(b);
 
 	cast!(f32x4(
-		crate::fma_f64(a.0, b.0, c.0),
-		crate::fma_f64(a.1, b.1, c.1),
-		crate::fma_f64(a.2, b.2, c.2),
-		crate::fma_f64(a.3, b.3, c.3),
+		crate::fma_f32(a.0, b.0, c.0),
+		crate::fma_f32(a.1, b.1, c.1),
+		crate::fma_f32(a.2, b.2, c.2),
+		crate::fma_f32(a.3, b.3, c.3),
 	))
 }
 
@@ -2751,153 +2751,153 @@ impl Neon {
 		unsafe { cast!(vbslq_u8(cast!(mask), cast!(if_true), cast!(if_false),)) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i16x8<const AMOUNT: i32>(self, a: i16x8) -> i16x8 {
 		unsafe { cast!(vshlq_n_s16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i32x4<const AMOUNT: i32>(self, a: i32x4) -> i32x4 {
 		unsafe { cast!(vshlq_n_s32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i64x2<const AMOUNT: i32>(self, a: i64x2) -> i64x2 {
 		unsafe { cast!(vshlq_n_s64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i8x16<const AMOUNT: i32>(self, a: i8x16) -> i8x16 {
 		unsafe { cast!(vshlq_n_s8::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u16x8<const AMOUNT: i32>(self, a: u16x8) -> u16x8 {
 		unsafe { cast!(vshlq_n_u16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u32x4<const AMOUNT: i32>(self, a: u32x4) -> u32x4 {
 		unsafe { cast!(vshlq_n_u32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u64x2<const AMOUNT: i32>(self, a: u64x2) -> u64x2 {
 		unsafe { cast!(vshlq_n_u64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u8x16<const AMOUNT: i32>(self, a: u8x16) -> u8x16 {
 		unsafe { cast!(vshlq_n_u8::<AMOUNT>(cast!(a))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i16x8(self, a: i16x8, amount: i16x8) -> i16x8 {
 		unsafe { cast!(vshlq_u16(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i32x4(self, a: i32x4, amount: i32x4) -> i32x4 {
 		unsafe { cast!(vshlq_u32(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i64x2(self, a: i64x2, amount: i64x2) -> i64x2 {
 		unsafe { cast!(vshlq_u64(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i8x16(self, a: i8x16, amount: i8x16) -> i8x16 {
 		unsafe { cast!(vshlq_u8(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u16x8(self, a: u16x8, amount: i16x8) -> u16x8 {
 		unsafe { cast!(vshlq_u16(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u32x4(self, a: u32x4, amount: i32x4) -> u32x4 {
 		unsafe { cast!(vshlq_u32(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u64x2(self, a: u64x2, amount: i64x2) -> u64x2 {
 		unsafe { cast!(vshlq_u64(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u8x16(self, a: u8x16, amount: i8x16) -> u8x16 {
 		unsafe { cast!(vshlq_u8(cast!(a), cast!(amount))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i16x8<const AMOUNT: i32>(self, a: i16x8) -> i16x8 {
 		unsafe { cast!(vshrq_n_s16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i32x4<const AMOUNT: i32>(self, a: i32x4) -> i32x4 {
 		unsafe { cast!(vshrq_n_s32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i64x2<const AMOUNT: i32>(self, a: i64x2) -> i64x2 {
 		unsafe { cast!(vshrq_n_s64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i8x16<const AMOUNT: i32>(self, a: i8x16) -> i8x16 {
 		unsafe { cast!(vshrq_n_s8::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u16x8<const AMOUNT: i32>(self, a: u16x8) -> u16x8 {
 		unsafe { cast!(vshrq_n_u16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u32x4<const AMOUNT: i32>(self, a: u32x4) -> u32x4 {
 		unsafe { cast!(vshrq_n_u32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u64x2<const AMOUNT: i32>(self, a: u64x2) -> u64x2 {
 		unsafe { cast!(vshrq_n_u64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u8x16<const AMOUNT: i32>(self, a: u8x16) -> u8x16 {
 		unsafe { cast!(vshrq_n_u8::<AMOUNT>(cast!(a))) }


### PR DESCRIPTION
I am uncertain whether this is an appropriate change, but with my limited context, it seems types got mismatched the last time these lines were updated.
<img width="1146" height="868" alt="Screenshot 2025-09-30 at 06 56 00" src="https://github.com/user-attachments/assets/617cad57-ad65-49ac-9e5d-afe8ad5e950b" />


Before PR:
```
$ cargo +nightly miri test
   Compiling pulp v0.21.5 (/potato/pulp/pulp)
error[E0308]: arguments to this function are incorrect
    --> pulp/src/aarch64.rs:2258:3
     |
2258 |         crate::fma_f32(a.0, b.0, c.0),
     |         ^^^^^^^^^^^^^^ ---  ---  --- expected `f32`, found `f64`
     |                        |    |
     |                        |    expected `f32`, found `f64`
     |                        expected `f32`, found `f64`
     |
note: function defined here
    --> pulp/src/lib.rs:372:4
     |
372  | fn fma_f32(a: f32, b: f32, c: f32) -> f32 {
     |    ^^^^^^^ ------  ------  ------

error[E0308]: arguments to this function are incorrect
    --> pulp/src/aarch64.rs:2259:3
     |
2259 |         crate::fma_f32(a.1, b.1, c.1),
     |         ^^^^^^^^^^^^^^ ---  ---  --- expected `f32`, found `f64`
     |                        |    |
     |                        |    expected `f32`, found `f64`
     |                        expected `f32`, found `f64`
     |
note: function defined here
    --> pulp/src/lib.rs:372:4
     |
372  | fn fma_f32(a: f32, b: f32, c: f32) -> f32 {
     |    ^^^^^^^ ------  ------  ------

error[E0308]: arguments to this struct are incorrect
    --> pulp/src/aarch64.rs:2257:8
     |
2257 |     cast!(f64x2(
     |           ^^^^^
2258 |         crate::fma_f32(a.0, b.0, c.0),
     |         ----------------------------- expected `f64`, found `f32`
2259 |         crate::fma_f32(a.1, b.1, c.1),
     |         ----------------------------- expected `f64`, found `f32`
     |
note: tuple struct defined here
    --> pulp/src/lib.rs:4820:12
     |
4820 | pub struct f64x2(pub f64, pub f64);
     |            ^^^^^
help: you can convert an `f32` to an `f64`
     |
2258 |         crate::fma_f32(a.0, b.0, c.0).into(),
     |                                      +++++++
help: you can convert an `f32` to an `f64`
     |
2259 |         crate::fma_f32(a.1, b.1, c.1).into(),
     |                                      +++++++

error[E0308]: arguments to this function are incorrect
    --> pulp/src/aarch64.rs:2270:3
     |
2270 |         crate::fma_f64(a.0, b.0, c.0),
     |         ^^^^^^^^^^^^^^ ---  ---  --- expected `f64`, found `f32`
     |                        |    |
     |                        |    expected `f64`, found `f32`
     |                        expected `f64`, found `f32`
     |
note: function defined here
    --> pulp/src/lib.rs:380:4
     |
380  | fn fma_f64(a: f64, b: f64, c: f64) -> f64 {
     |    ^^^^^^^ ------  ------  ------
help: you can convert an `f32` to an `f64`
     |
2270 |         crate::fma_f64(a.0.into(), b.0, c.0),
     |                           +++++++
help: you can convert an `f32` to an `f64`
     |
2270 |         crate::fma_f64(a.0, b.0.into(), c.0),
     |                                +++++++
help: you can convert an `f32` to an `f64`
     |
2270 |         crate::fma_f64(a.0, b.0, c.0.into()),
     |                                     +++++++

error[E0308]: arguments to this function are incorrect
    --> pulp/src/aarch64.rs:2271:3
     |
2271 |         crate::fma_f64(a.1, b.1, c.1),
     |         ^^^^^^^^^^^^^^ ---  ---  --- expected `f64`, found `f32`
     |                        |    |
     |                        |    expected `f64`, found `f32`
     |                        expected `f64`, found `f32`
     |
note: function defined here
    --> pulp/src/lib.rs:380:4
     |
380  | fn fma_f64(a: f64, b: f64, c: f64) -> f64 {
     |    ^^^^^^^ ------  ------  ------
help: you can convert an `f32` to an `f64`
     |
2271 |         crate::fma_f64(a.1.into(), b.1, c.1),
     |                           +++++++
help: you can convert an `f32` to an `f64`
     |
2271 |         crate::fma_f64(a.1, b.1.into(), c.1),
     |                                +++++++
help: you can convert an `f32` to an `f64`
     |
2271 |         crate::fma_f64(a.1, b.1, c.1.into()),
     |                                     +++++++

error[E0308]: arguments to this function are incorrect
    --> pulp/src/aarch64.rs:2272:3
     |
2272 |         crate::fma_f64(a.2, b.2, c.2),
     |         ^^^^^^^^^^^^^^ ---  ---  --- expected `f64`, found `f32`
     |                        |    |
     |                        |    expected `f64`, found `f32`
     |                        expected `f64`, found `f32`
     |
note: function defined here
    --> pulp/src/lib.rs:380:4
     |
380  | fn fma_f64(a: f64, b: f64, c: f64) -> f64 {
     |    ^^^^^^^ ------  ------  ------
help: you can convert an `f32` to an `f64`
     |
2272 |         crate::fma_f64(a.2.into(), b.2, c.2),
     |                           +++++++
help: you can convert an `f32` to an `f64`
     |
2272 |         crate::fma_f64(a.2, b.2.into(), c.2),
     |                                +++++++
help: you can convert an `f32` to an `f64`
     |
2272 |         crate::fma_f64(a.2, b.2, c.2.into()),
     |                                     +++++++

error[E0308]: arguments to this function are incorrect
    --> pulp/src/aarch64.rs:2273:3
     |
2273 |         crate::fma_f64(a.3, b.3, c.3),
     |         ^^^^^^^^^^^^^^ ---  ---  --- expected `f64`, found `f32`
     |                        |    |
     |                        |    expected `f64`, found `f32`
     |                        expected `f64`, found `f32`
     |
note: function defined here
    --> pulp/src/lib.rs:380:4
     |
380  | fn fma_f64(a: f64, b: f64, c: f64) -> f64 {
     |    ^^^^^^^ ------  ------  ------
help: you can convert an `f32` to an `f64`
     |
2273 |         crate::fma_f64(a.3.into(), b.3, c.3),
     |                           +++++++
help: you can convert an `f32` to an `f64`
     |
2273 |         crate::fma_f64(a.3, b.3.into(), c.3),
     |                                +++++++
help: you can convert an `f32` to an `f64`
     |
2273 |         crate::fma_f64(a.3, b.3, c.3.into()),
     |                                     +++++++

error[E0308]: arguments to this struct are incorrect
    --> pulp/src/aarch64.rs:2269:8
     |
2269 |     cast!(f32x4(
     |           ^^^^^
2270 |         crate::fma_f64(a.0, b.0, c.0),
     |         ----------------------------- expected `f32`, found `f64`
2271 |         crate::fma_f64(a.1, b.1, c.1),
     |         ----------------------------- expected `f32`, found `f64`
2272 |         crate::fma_f64(a.2, b.2, c.2),
     |         ----------------------------- expected `f32`, found `f64`
2273 |         crate::fma_f64(a.3, b.3, c.3),
     |         ----------------------------- expected `f32`, found `f64`
     |
note: tuple struct defined here
    --> pulp/src/lib.rs:4587:12
     |
4587 | pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
     |            ^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `pulp` (lib) due to 8 previous errors
```

After PR:

```
$ cargo +nightly miri test
   Compiling pulp v0.21.5 (/potato/pulp/pulp)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.97s
     Running unittests src/lib.rs (target/miri/aarch64-apple-darwin/debug/deps/pulp-1b542ecd6c698720)

running 4 tests
test aarch64::tests::test_cplx32_mul ... error: unsupported operation: inline assembly is not supported
    --> pulp/src/aarch64.rs:44:2
     |
44   | /     asm!(
45   | |         "fcmla {0:v}.4s, {1:v}.4s, {2:v}.4s, 0",
46   | |         inout(vreg) acc,
47   | |         in(vreg) lhs,
48   | |         in(vreg) rhs,
49   | |         options(pure, nomem, nostack));
     | |______________________________________^ unsupported operation occurred here
     |
     = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
     = note: BACKTRACE on thread `aarch64::tests::test_cplx32_mul`:
     = note: inside `aarch64::vcmlaq_0_f32` at pulp/src/aarch64.rs:44:2: 49:39
note: inside `<aarch64::NeonFcma as Simd>::mul_add_c32s`
    --> pulp/src/aarch64.rs:1919:32
     |
1919 |         unsafe { cast!(vcmlaq_90_f32(vcmlaq_0_f32(c, a, b), a, b)) }
     |                                      ^^^^^^^^^^^^^^^^^^^^^
note: inside `<aarch64::NeonFcma as Simd>::mul_c32s`
    --> pulp/src/aarch64.rs:1952:3
     |
1952 |         self.mul_add_c32s(a, b, self.splat_f32s(0.0))
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `aarch64::tests::test_cplx32_mul`
    --> pulp/src/aarch64.rs:3337:13
     |
3337 |                 let c = simd.mul_c32s(a, b);
     |                         ^^^^^^^^^^^^^^^^^^^
note: inside closure
    --> pulp/src/aarch64.rs:3282:22
     |
3281 |     #[test]
     |     ------- in this procedural macro expansion
3282 |     fn test_cplx32_mul() {
     |                         ^

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error

error: test failed, to rerun pass `-p pulp --lib`
```

Granted, this now leads to a different `miri` error 😬.

Also, my editor auto-trimmed comment extra spaces. I can do a separate PR if you'd rather keep them.