### PR TITLE
bypass aarch64 tests in miri on macos

### DIFF
--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -3224,6 +3224,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(not(miri))]
 	fn test_cplx64_mul() {
 		for _ in 0..100 {
 			let a = f64x2(random(), random());
@@ -3279,6 +3280,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(not(miri))]
 	fn test_cplx32_mul() {
 		for _ in 0..100 {
 			let a = f32x4(random(), random(), random(), random());
@@ -3374,6 +3376,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(not(miri))]
 	fn test_rotate() {
 		if let Some(simd) = Neon::try_new() {
 			for amount in 0..128 {
@@ -3402,6 +3405,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(not(miri))]
 	fn test_interleave() {
 		if let Some(simd) = Neon::try_new() {
 			{

--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -2255,8 +2255,8 @@ unsafe fn vfmaq_f64(c: float64x2_t, a: float64x2_t, b: float64x2_t) -> float64x2
 	let b: f64x2 = cast!(b);
 
 	cast!(f64x2(
-		crate::fma_f32(a.0, b.0, c.0),
-		crate::fma_f32(a.1, b.1, c.1),
+		crate::fma_f64(a.0, b.0, c.0),
+		crate::fma_f64(a.1, b.1, c.1),
 	))
 }
 
@@ -2267,10 +2267,10 @@ unsafe fn vfmaq_f32(c: float32x4_t, a: float32x4_t, b: float32x4_t) -> float32x4
 	let b: f32x4 = cast!(b);
 
 	cast!(f32x4(
-		crate::fma_f64(a.0, b.0, c.0),
-		crate::fma_f64(a.1, b.1, c.1),
-		crate::fma_f64(a.2, b.2, c.2),
-		crate::fma_f64(a.3, b.3, c.3),
+		crate::fma_f32(a.0, b.0, c.0),
+		crate::fma_f32(a.1, b.1, c.1),
+		crate::fma_f32(a.2, b.2, c.2),
+		crate::fma_f32(a.3, b.3, c.3),
 	))
 }
 
@@ -2751,153 +2751,153 @@ impl Neon {
 		unsafe { cast!(vbslq_u8(cast!(mask), cast!(if_true), cast!(if_false),)) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i16x8<const AMOUNT: i32>(self, a: i16x8) -> i16x8 {
 		unsafe { cast!(vshlq_n_s16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i32x4<const AMOUNT: i32>(self, a: i32x4) -> i32x4 {
 		unsafe { cast!(vshlq_n_s32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i64x2<const AMOUNT: i32>(self, a: i64x2) -> i64x2 {
 		unsafe { cast!(vshlq_n_s64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_i8x16<const AMOUNT: i32>(self, a: i8x16) -> i8x16 {
 		unsafe { cast!(vshlq_n_s8::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u16x8<const AMOUNT: i32>(self, a: u16x8) -> u16x8 {
 		unsafe { cast!(vshlq_n_u16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u32x4<const AMOUNT: i32>(self, a: u32x4) -> u32x4 {
 		unsafe { cast!(vshlq_n_u32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u64x2<const AMOUNT: i32>(self, a: u64x2) -> u64x2 {
 		unsafe { cast!(vshlq_n_u64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_const_u8x16<const AMOUNT: i32>(self, a: u8x16) -> u8x16 {
 		unsafe { cast!(vshlq_n_u8::<AMOUNT>(cast!(a))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i16x8(self, a: i16x8, amount: i16x8) -> i16x8 {
 		unsafe { cast!(vshlq_u16(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i32x4(self, a: i32x4, amount: i32x4) -> i32x4 {
 		unsafe { cast!(vshlq_u32(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i64x2(self, a: i64x2, amount: i64x2) -> i64x2 {
 		unsafe { cast!(vshlq_u64(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_i8x16(self, a: i8x16, amount: i8x16) -> i8x16 {
 		unsafe { cast!(vshlq_u8(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u16x8(self, a: u16x8, amount: i16x8) -> u16x8 {
 		unsafe { cast!(vshlq_u16(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u32x4(self, a: u32x4, amount: i32x4) -> u32x4 {
 		unsafe { cast!(vshlq_u32(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u64x2(self, a: u64x2, amount: i64x2) -> u64x2 {
 		unsafe { cast!(vshlq_u64(cast!(a), cast!(amount))) }
 	}
 
 	/// Shift the bits of each lane of `a` to the left by the element in the corresponding lane in
-	/// `amount`, while shifting in zeros.  
+	/// `amount`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shl_dyn_u8x16(self, a: u8x16, amount: i8x16) -> u8x16 {
 		unsafe { cast!(vshlq_u8(cast!(a), cast!(amount))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i16x8<const AMOUNT: i32>(self, a: i16x8) -> i16x8 {
 		unsafe { cast!(vshrq_n_s16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i32x4<const AMOUNT: i32>(self, a: i32x4) -> i32x4 {
 		unsafe { cast!(vshrq_n_s32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i64x2<const AMOUNT: i32>(self, a: i64x2) -> i64x2 {
 		unsafe { cast!(vshrq_n_s64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in sign bits.
 	#[inline(always)]
 	pub fn shr_const_i8x16<const AMOUNT: i32>(self, a: i8x16) -> i8x16 {
 		unsafe { cast!(vshrq_n_s8::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u16x8<const AMOUNT: i32>(self, a: u16x8) -> u16x8 {
 		unsafe { cast!(vshrq_n_u16::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u32x4<const AMOUNT: i32>(self, a: u32x4) -> u32x4 {
 		unsafe { cast!(vshrq_n_u32::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u64x2<const AMOUNT: i32>(self, a: u64x2) -> u64x2 {
 		unsafe { cast!(vshrq_n_u64::<AMOUNT>(cast!(a))) }
 	}
 
-	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.  
+	/// Shift the bits of each lane of `a` to the left by `AMOUNT`, while shifting in zeros.
 	#[inline(always)]
 	pub fn shr_const_u8x16<const AMOUNT: i32>(self, a: u8x16) -> u8x16 {
 		unsafe { cast!(vshrq_n_u8::<AMOUNT>(cast!(a))) }

--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -3224,7 +3224,7 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(not(miri))]
+	#[cfg(not(all(miri, target_arch = "aarch64", target_os = "macos")))]
 	fn test_cplx64_mul() {
 		for _ in 0..100 {
 			let a = f64x2(random(), random());
@@ -3280,7 +3280,7 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(not(miri))]
+	#[cfg(not(all(miri, target_arch = "aarch64", target_os = "macos")))]
 	fn test_cplx32_mul() {
 		for _ in 0..100 {
 			let a = f32x4(random(), random(), random(), random());
@@ -3376,7 +3376,7 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(not(miri))]
+	#[cfg(not(all(miri, target_arch = "aarch64", target_os = "macos")))]
 	fn test_rotate() {
 		if let Some(simd) = Neon::try_new() {
 			for amount in 0..128 {
@@ -3405,7 +3405,7 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg(not(miri))]
+	#[cfg(not(all(miri, target_arch = "aarch64", target_os = "macos")))]
 	fn test_interleave() {
 		if let Some(simd) = Neon::try_new() {
 			{


### PR DESCRIPTION
> [!NOTE] 
> This PR builds on #22. I'll make it ready once that one is merged.

I am not sure if this is a bridge too far. My original problem was that when I ran miri on my code that uses `faer`, I could not compile. I believe #22 will fix that. This PR attempts to run miri test against `pulp` itself (instead of my code), so I'm not sure if that matters or is desirable. Nevertheless, here's a proposal in case it is useful.

As reported in #22, running miri test complains about inline assembly:
```
$ cargo +nightly miri test
   Compiling pulp v0.21.5 (/potato/pulp/pulp)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.97s
     Running unittests src/lib.rs (target/miri/aarch64-apple-darwin/debug/deps/pulp-1b542ecd6c698720)

running 4 tests
test aarch64::tests::test_cplx32_mul ... error: unsupported operation: inline assembly is not supported
    --> pulp/src/aarch64.rs:44:2
     |
44   | /     asm!(
45   | |         "fcmla {0:v}.4s, {1:v}.4s, {2:v}.4s, 0",
46   | |         inout(vreg) acc,
47   | |         in(vreg) lhs,
48   | |         in(vreg) rhs,
49   | |         options(pure, nomem, nostack));
     | |______________________________________^ unsupported operation occurred here
     |
     = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
     = note: BACKTRACE on thread `aarch64::tests::test_cplx32_mul`:
     = note: inside `aarch64::vcmlaq_0_f32` at pulp/src/aarch64.rs:44:2: 49:39
note: inside `<aarch64::NeonFcma as Simd>::mul_add_c32s`
    --> pulp/src/aarch64.rs:1919:32
     |
1919 |         unsafe { cast!(vcmlaq_90_f32(vcmlaq_0_f32(c, a, b), a, b)) }
     |                                      ^^^^^^^^^^^^^^^^^^^^^
note: inside `<aarch64::NeonFcma as Simd>::mul_c32s`
    --> pulp/src/aarch64.rs:1952:3
     |
1952 |         self.mul_add_c32s(a, b, self.splat_f32s(0.0))
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `aarch64::tests::test_cplx32_mul`
    --> pulp/src/aarch64.rs:3337:13
     |
3337 |                 let c = simd.mul_c32s(a, b);
     |                         ^^^^^^^^^^^^^^^^^^^
note: inside closure
    --> pulp/src/aarch64.rs:3282:22
     |
3281 |     #[test]
     |     ------- in this procedural macro expansion
3282 |     fn test_cplx32_mul() {
     |                         ^

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error

error: test failed, to rerun pass `-p pulp --lib
```

Initially, I considered bypassing inline assembly for miri directly:
```diff
diff --git a/pulp/src/aarch64.rs b/pulp/src/aarch64.rs
index 98ca75f..03ae7d2 100644
--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -5,6 +5,11 @@ use core::arch::asm;
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 unsafe fn vcmlaq_0_f64(mut acc: float64x2_t, lhs: float64x2_t, rhs: float64x2_t) -> float64x2_t {
+       #[cfg(miri)]
+       {
+               // Miri does not support inline assembly.
+               return vfmaq_f64(acc, lhs, rhs);
+       }
        asm!(
         "fcmla {0:v}.2d, {1:v}.2d, {2:v}.2d, 0",
         inout(vreg) acc,
@@ -17,6 +22,11 @@ unsafe fn vcmlaq_0_f64(mut acc: float64x2_t, lhs: float64x2_t, rhs: float64x2_t)
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 unsafe fn vcmlaq_90_f64(mut acc: float64x2_t, lhs: float64x2_t, rhs: float64x2_t) -> float64x2_t {
+       #[cfg(miri)]
+       {
+               // Miri does not support inline assembly.
+               return vfmaq_f64(acc, lhs, rhs);
+       }
        asm!(
         "fcmla {0:v}.2d, {1:v}.2d, {2:v}.2d, 90",
         inout(vreg) acc,
@@ -41,6 +51,11 @@ unsafe fn vcmlaq_270_f64(mut acc: float64x2_t, lhs: float64x2_t, rhs: float64x2_
 #[inline]
 #[target_feature(enable = "neon,fcma")]
 unsafe fn vcmlaq_0_f32(mut acc: float32x4_t, lhs: float32x4_t, rhs: float32x4_t) -> float32x4_t {
+       #[cfg(miri)]
+       {
+               // Miri does not support inline assembly.
+               return vfmaq_f32(acc, lhs, rhs);
+       }
        asm!(
         "fcmla {0:v}.4s, {1:v}.4s, {2:v}.4s, 0",
         inout(vreg) acc,
```

However, even with that workaround, we end up running into miri/intrinsics compatibility issues, e.g.:
```
...
test aarch64::tests::test_rotate ... error: unsupported operation: can't call foreign function `llvm.aarch64.neon.tbl1.v16i8` on OS `macos`
...
```

It appears that there is a path for miri to support intrinsics eventually, but today is not that day (https://github.com/rust-lang/stdarch/issues/805, https://github.com/rust-lang/stdarch/issues/1659).

So, I ended up bypassing the aarch64 tests in miri on macos.