### PR TITLE
Fix build with nightly-x86-v4 feature enabled

### DIFF
--- a/pulp/Cargo.toml
+++ b/pulp/Cargo.toml
@@ -25,7 +25,7 @@ default = [
   "x86-v3",
 ]
 nightly = [
-  "bytemuck/nightly_stdsimd",
+  "bytemuck/avx512_simd",
 ]
 std = []
 


### PR DESCRIPTION
`bytemuck` has removed the nightly feature in https://github.com/Lokathor/bytemuck/pull/322 when AVX-512 intrinsics were stabilized in Rust v1.89. This currently causes the build of `pulp` to fail when the nightly-x86-v4 feature is enabled.