### PR TITLE
Add negate_mul_add ops to Simd Trait

### DIFF
--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -1060,6 +1060,26 @@ impl Simd for Neon {
 	}
 
 	#[inline(always)]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.negate_mul_add_f32s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.negate_mul_add_f64s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.negate_mul_add_f32x4(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.negate_mul_add_f64x2(a, b, c)
+	}
+
+	#[inline(always)]
 	fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
 		unsafe {
 			let ab = cast!(a);
@@ -2680,6 +2700,18 @@ impl Neon {
 		unsafe { cast!(vfmaq_f64(cast!(c), cast!(a), cast!(b))) }
 	}
 
+	/// Multiplies the elements of each lane of `a` and `b` and adds the result to `c`.
+	#[inline(always)]
+	pub fn negate_mul_add_f32x4(self, a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+		unsafe { cast!(vfmsq_f32(cast!(c), cast!(a), cast!(b))) }
+	}
+
+	/// Multiplies the elements of each lane of `a` and `b` and adds the result to `c`.
+	#[inline(always)]
+	pub fn negate_mul_add_f64x2(self, a: f64x2, b: f64x2, c: f64x2) -> f64x2 {
+		unsafe { cast!(vfmsq_f64(cast!(c), cast!(a), cast!(b))) }
+	}
+
 	/// Returns the bitwise NOT of `a`.
 	#[inline(always)]
 	pub fn not_i16x8(self, a: i16x8) -> i16x8 {
@@ -3587,6 +3619,48 @@ mod tests {
 				assert_eq!(dst[3], simd.add_f32x4(dst[0], simd.splat_f32x4(0.3)));
 				assert_eq!(src, simd.interleave_shfl_f32s(dst));
 			}
+		}
+	}
+
+	#[test]
+	fn test_mul_add() {
+		if let Some(simd) = Neon::try_new() {
+			let a = f32x4(-1.0, 1.0, -2.0, 2.0);
+			let b = f32x4(-5.0, 5.0, -6.0, 6.0);
+			let c = f32x4(2.0, -2.0, -3.0, 3.0);
+
+			let d = simd.add_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.mul_add_f32s(a, b, c), d);
+
+			let a = f64x2(-1.0, 1.0);
+			let b = f64x2(-5.0, 5.0);
+			let c = f64x2(2.0, -2.0);
+
+			let d = simd.add_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.mul_add_f64s(a, b, c), d);
+		}
+	}
+
+	#[test]
+	fn test_negate_mul_add() {
+		if let Some(simd) = Neon::try_new() {
+			let a = f32x4(-1.0, 1.0, -2.0, 2.0);
+			let b = f32x4(-5.0, 5.0, -6.0, 6.0);
+			let c = f32x4(2.0, -2.0, -3.0, 3.0);
+
+			let d = simd.sub_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f32s(a, b, c), d);
+
+			let a = f64x2(-1.0, 1.0);
+			let b = f64x2(-5.0, 5.0);
+			let c = f64x2(2.0, -2.0);
+
+			let d = simd.sub_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f64s(a, b, c), d);
 		}
 	}
 }

--- a/pulp/src/lib.rs
+++ b/pulp/src/lib.rs
@@ -1116,6 +1116,13 @@ pub trait Simd: Seal + Debug + Copy + Send + Sync + 'static {
 	fn mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
 	fn mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
 	fn mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+
+	/// Computes `-a * b + c`
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+
 	/// Computes `a * b`
 	#[inline]
 	fn mul_e_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
@@ -1958,6 +1965,21 @@ macro_rules! scalar_simd {
 			}
 
 			#[inline]
+			fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+				let mut out = [0.0f32; Self::F32_LANES];
+
+				let a: [f32; Self::F32_LANES] = cast(a);
+				let b: [f32; Self::F32_LANES] = cast(b);
+				let c: [f32; Self::F32_LANES] = cast(c);
+
+				for i in 0..Self::F32_LANES {
+					out[i] = fma_f32(-a[i], b[i], c[i]);
+				}
+
+				cast(out)
+			}
+
+			#[inline]
 			fn reduce_sum_f32s(self, a: Self::f32s) -> f32 {
 				let mut a: [f32; Self::F32_LANES] = cast(a);
 
@@ -2209,6 +2231,20 @@ macro_rules! scalar_simd {
 			}
 
 			#[inline]
+			fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+				let mut out = [0.0f64; Self::F64_LANES];
+				let a: [f64; Self::F64_LANES] = cast(a);
+				let b: [f64; Self::F64_LANES] = cast(b);
+				let c: [f64; Self::F64_LANES] = cast(c);
+
+				for i in 0..Self::F64_LANES {
+					out[i] = fma_f64(-a[i], b[i], c[i]);
+				}
+
+				cast(out)
+			}
+
+			#[inline]
 			fn reduce_sum_f64s(self, a: Self::f64s) -> f64 {
 				let mut a: [f64; Self::F64_LANES] = cast(a);
 
@@ -2453,6 +2489,16 @@ macro_rules! scalar_simd {
 			#[inline]
 			fn mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
 				self.mul_add_f64s(a, b, c)
+			}
+
+			#[inline]
+			fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+				self.negate_mul_add_f32s(a, b, c)
+			}
+
+			#[inline]
+			fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+				self.negate_mul_add_f64s(a, b, c)
 			}
 
 			#[inline(always)]
@@ -2858,6 +2904,26 @@ impl Simd for Scalar {
 	#[inline]
 	fn mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
 		fma_f64(a, b, c)
+	}
+
+	#[inline]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		c - a * b
+	}
+
+	#[inline]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		c - a * b
+	}
+
+	#[inline]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		fma_f32(-a, b, c)
+	}
+
+	#[inline]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		fma_f64(-a, b, c)
 	}
 
 	#[inline]

--- a/pulp/src/wasm.rs
+++ b/pulp/src/wasm.rs
@@ -836,6 +836,31 @@ impl Simd for Simd128 {
 	}
 
 	#[inline(always)]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		vfmsq_f32(c, a, b)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		vfmsq_f64(c, a, b)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		f32x4(
+			fma_f32(-a.0, b.0, c.0),
+			fma_f32(-a.1, b.1, c.1),
+			fma_f32(-a.2, b.2, c.2),
+			fma_f32(-a.3, b.3, c.3),
+		)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		f64x2(fma_f64(-a.0, b.0, c.0), fma_f64(-a.1, b.1, c.1))
+	}
+
+	#[inline(always)]
 	fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
 		let ab = cast!(a);
 		let xy = cast!(b);
@@ -2364,6 +2389,24 @@ fn vfmaq_f32(c: f32x4, a: f32x4, b: f32x4) -> f32x4 {
 	cast!(
 		simd.simd128
 			.f32x4_add(cast!(c), simd.simd128.f32x4_mul(cast!(a), cast!(b)))
+	)
+}
+
+#[inline(always)]
+fn vfmsq_f64(c: f64x2, a: f64x2, b: f64x2) -> f64x2 {
+	let simd = unsafe { Simd128::new_unchecked() };
+	cast!(
+		simd.simd128
+			.f64x2_sub(cast!(c), simd.simd128.f64x2_mul(cast!(a), cast!(b)))
+	)
+}
+
+#[inline(always)]
+fn vfmsq_f32(c: f32x4, a: f32x4, b: f32x4) -> f32x4 {
+	let simd = unsafe { Simd128::new_unchecked() };
+	cast!(
+		simd.simd128
+			.f32x4_sub(cast!(c), simd.simd128.f32x4_mul(cast!(a), cast!(b)))
 	)
 }
 

--- a/pulp/src/x86.rs
+++ b/pulp/src/x86.rs
@@ -1011,4 +1011,134 @@ mod tests {
 			}
 		}
 	}
+
+	#[test]
+	fn test_mul_add() {
+		if let Some(simd) = V2::try_new() {
+			let a = f32x4(-1.0, 1.0, -2.0, 2.0);
+			let b = f32x4(-5.0, 5.0, -6.0, 6.0);
+			let c = f32x4(2.0, -2.0, -3.0, 3.0);
+
+			let d = simd.add_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.mul_add_f32s(a, b, c), d);
+
+			let a = f64x2(-1.0, 1.0);
+			let b = f64x2(-5.0, 5.0);
+			let c = f64x2(2.0, -2.0);
+
+			let d = simd.add_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.mul_add_f64s(a, b, c), d);
+		}
+		if let Some(simd) = V3::try_new() {
+			let a = f32x8(-1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0);
+			let b = f32x8(-5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0, 8.0);
+			let c = f32x8(2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0);
+
+			let d = simd.add_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.mul_add_f32s(a, b, c), d);
+
+			let a = f64x4(-1.0, 1.0, -2.0, 2.0);
+			let b = f64x4(-5.0, 5.0, -6.0, 6.0);
+			let c = f64x4(2.0, -2.0, -3.0, 3.0);
+
+			let d = simd.add_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.mul_add_f64s(a, b, c), d);
+		}
+		#[cfg(feature = "x86-v4")]
+		if let Some(simd) = V4::try_new() {
+			let a = f32x16(
+				-1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0,
+				-4.0,
+			);
+			let b = f32x16(
+				-5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0, 8.0, -5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0,
+				8.0,
+			);
+			let c = f32x16(
+				2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0, 2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0,
+				5.0,
+			);
+
+			let d = simd.add_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.mul_add_f32s(a, b, c), d);
+
+			let a = f64x8(-1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0);
+			let b = f64x8(-5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0, 8.0);
+			let c = f64x8(2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0);
+
+			let d = simd.add_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.mul_add_f64s(a, b, c), d);
+		}
+	}
+
+	#[test]
+	fn test_negate_mul_add() {
+		if let Some(simd) = V2::try_new() {
+			let a = f32x4(-1.0, 1.0, -2.0, 2.0);
+			let b = f32x4(-5.0, 5.0, -6.0, 6.0);
+			let c = f32x4(2.0, -2.0, -3.0, 3.0);
+
+			let d = simd.sub_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f32s(a, b, c), d);
+
+			let a = f64x2(-1.0, 1.0);
+			let b = f64x2(-5.0, 5.0);
+			let c = f64x2(2.0, -2.0);
+
+			let d = simd.sub_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f64s(a, b, c), d);
+		}
+		if let Some(simd) = V3::try_new() {
+			let a = f32x8(-1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0);
+			let b = f32x8(-5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0, 8.0);
+			let c = f32x8(2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0);
+
+			let d = simd.sub_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f32s(a, b, c), d);
+
+			let a = f64x4(-1.0, 1.0, -2.0, 2.0);
+			let b = f64x4(-5.0, 5.0, -6.0, 6.0);
+			let c = f64x4(2.0, -2.0, -3.0, 3.0);
+
+			let d = simd.sub_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f64s(a, b, c), d);
+		}
+		#[cfg(feature = "x86-v4")]
+		if let Some(simd) = V4::try_new() {
+			let a = f32x16(
+				-1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0,
+				-4.0,
+			);
+			let b = f32x16(
+				-5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0, 8.0, -5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0,
+				8.0,
+			);
+			let c = f32x16(
+				2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0, 2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0,
+				5.0,
+			);
+
+			let d = simd.sub_f32s(c, simd.mul_f32s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f32s(a, b, c), d);
+
+			let a = f64x8(-1.0, 1.0, -2.0, 2.0, -3.0, 3.0, -4.0, 4.0);
+			let b = f64x8(-5.0, 5.0, -6.0, 6.0, -7.0, 7.0, -8.0, 8.0);
+			let c = f64x8(2.0, -2.0, -3.0, 3.0, -4.0, 4.0, -5.0, 5.0);
+
+			let d = simd.sub_f64s(c, simd.mul_f64s(a, b));
+
+			assert_eq!(simd.negate_mul_add_f64s(a, b, c), d);
+		}
+	}
 }

--- a/pulp/src/x86/v2.rs
+++ b/pulp/src/x86/v2.rs
@@ -924,6 +924,26 @@ impl Simd for V2 {
 	}
 
 	#[inline(always)]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.negate_mul_add_f32s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.negate_mul_add_f64s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		Scalar128b.negate_mul_add_f32s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		Scalar128b.negate_mul_add_f64s(a, b, c)
+	}
+
+	#[inline(always)]
 	fn neg_c32s(self, a: Self::c32s) -> Self::c32s {
 		self.xor_f32s(a, self.splat_f32s(-0.0))
 	}

--- a/pulp/src/x86/v3.rs
+++ b/pulp/src/x86/v3.rs
@@ -895,12 +895,12 @@ impl Simd for V3 {
 
 	#[inline(always)]
 	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
-		self.mul_add_f32s(a, b, c)
+		self.negate_mul_add_f32s(a, b, c)
 	}
 
 	#[inline(always)]
 	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
-		self.mul_add_f64s(a, b, c)
+		self.negate_mul_add_f64s(a, b, c)
 	}
 
 	#[inline(always)]

--- a/pulp/src/x86/v3.rs
+++ b/pulp/src/x86/v3.rs
@@ -894,6 +894,26 @@ impl Simd for V3 {
 	}
 
 	#[inline(always)]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.mul_add_f32s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.mul_add_f64s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		cast!(self.fma._mm256_fnmadd_ps(cast!(a), cast!(b), cast!(c)))
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		cast!(self.fma._mm256_fnmadd_pd(cast!(a), cast!(b), cast!(c)))
+	}
+
+	#[inline(always)]
 	fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
 		let ab = cast!(a);
 		let xy = cast!(b);
@@ -1611,6 +1631,26 @@ impl Simd for V3_128b {
 	}
 
 	#[inline(always)]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.negate_mul_add_f32s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.negate_mul_add_f64s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.negate_mul_add_f32x4(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.negate_mul_add_f64x2(a, b, c)
+	}
+
+	#[inline(always)]
 	fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
 		let ab = cast!(a);
 		let xy = cast!(b);
@@ -2080,6 +2120,10 @@ impl Simd for V3_256b {
 		fn mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
 		fn mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
 		fn mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+		fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
+		fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+		fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
+		fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
 		fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s;
 		fn mul_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::c64s;
 		fn neg_c32s(self, a: Self::c32s) -> Self::c32s;
@@ -2274,6 +2318,10 @@ impl Simd for V3_512b {
 		fn mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
 		fn mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
 		fn mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+		fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
+		fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
+		fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s;
+		fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s;
 		fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s;
 		fn mul_c64s(self, a: Self::c64s, b: Self::c64s) -> Self::c64s;
 		fn mul_f32s(self, a: Self::f32s, b: Self::f32s) -> Self::f32s;

--- a/pulp/src/x86/v4.rs
+++ b/pulp/src/x86/v4.rs
@@ -1007,6 +1007,26 @@ impl Simd for V4 {
 	}
 
 	#[inline(always)]
+	fn negate_mul_add_e_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		cast!(self.avx512f._mm512_fnmadd_ps(cast!(a), cast!(b), cast!(c)))
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_e_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		cast!(self.avx512f._mm512_fnmadd_pd(cast!(a), cast!(b), cast!(c)))
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f32s(self, a: Self::f32s, b: Self::f32s, c: Self::f32s) -> Self::f32s {
+		self.negate_mul_add_e_f32s(a, b, c)
+	}
+
+	#[inline(always)]
+	fn negate_mul_add_f64s(self, a: Self::f64s, b: Self::f64s, c: Self::f64s) -> Self::f64s {
+		self.negate_mul_add_e_f64s(a, b, c)
+	}
+
+	#[inline(always)]
 	fn mul_c32s(self, a: Self::c32s, b: Self::c32s) -> Self::c32s {
 		let ab = cast!(a);
 		let xy = cast!(b);


### PR DESCRIPTION
Was in need of these operations for a small project of mine. There are of course workarounds to make it work without them, but was just cleaner with these.

The name was chosen to be consistent with the set of functions `negate_mul_add_f32x4` that were already present on x86(_64) V3's `impl`.

All of the patterns were done to be consistent with the existing `mul_add_fXX` implementations