### PR TITLE
feat: add byte shuffle/LUT primitives across all backends

### DIFF
--- a/pulp/src/aarch64.rs
+++ b/pulp/src/aarch64.rs
@@ -3302,6 +3302,26 @@ impl Neon {
 	pub fn xor_u8x16(self, a: u8x16, b: u8x16) -> u8x16 {
 		unsafe { cast!(veorq_u8(cast!(a), cast!(b))) }
 	}
+
+	/// Shuffles the bytes of `table` according to the byte indices in `idx`.
+	///
+	/// This is a 16-byte in-register lookup table (LUT) using the NEON `tbl`
+	/// instruction (`vqtbl1q_u8`). For each byte of `idx`, if the value is
+	/// `>= 16` the corresponding output byte is zero; otherwise it selects the
+	/// byte at that position from `table`.
+	#[inline(always)]
+	pub fn shuffle_u8x16(self, table: u8x16, idx: u8x16) -> u8x16 {
+		unsafe { cast!(vqtbl1q_u8(cast!(table), cast!(idx))) }
+	}
+
+	/// Signed-byte variant of [`Neon::shuffle_u8x16`].
+	///
+	/// Note: the index is still `u8x16` because NEON's `vqtbl1q_s8` requires an
+	/// unsigned index vector.
+	#[inline(always)]
+	pub fn shuffle_i8x16(self, table: i8x16, idx: u8x16) -> i8x16 {
+		unsafe { cast!(vqtbl1q_s8(cast!(table), cast!(idx))) }
+	}
 }
 
 /// aarch64 arch

--- a/pulp/src/wasm.rs
+++ b/pulp/src/wasm.rs
@@ -1201,6 +1201,39 @@ impl Simd for Simd128 {
 	}
 }
 
+impl Simd128 {
+	/// Shuffles the bytes of `table` according to the byte indices in `idx`.
+	///
+	/// This is a 16-byte in-register lookup table (LUT) backed by WebAssembly's
+	/// `i8x16.swizzle`. For each byte of `idx`, if the value is `>= 16` the
+	/// corresponding output byte is zero; otherwise it selects the byte at that
+	/// position from `table`.
+	#[inline(always)]
+	pub fn shuffle_u8x16(self, table: u8x16, idx: u8x16) -> u8x16 {
+		cast!(self.simd128.i8x16_swizzle(cast!(table), cast!(idx)))
+	}
+
+	/// Signed-byte variant of [`Simd128::shuffle_u8x16`].
+	#[inline(always)]
+	pub fn shuffle_i8x16(self, table: i8x16, idx: u8x16) -> i8x16 {
+		cast!(self.simd128.i8x16_swizzle(cast!(table), cast!(idx)))
+	}
+}
+
+impl RelaxedSimd {
+	/// See [`Simd128::shuffle_u8x16`].
+	#[inline(always)]
+	pub fn shuffle_u8x16(self, table: u8x16, idx: u8x16) -> u8x16 {
+		cast!(self.simd128.i8x16_swizzle(cast!(table), cast!(idx)))
+	}
+
+	/// See [`Simd128::shuffle_i8x16`].
+	#[inline(always)]
+	pub fn shuffle_i8x16(self, table: i8x16, idx: u8x16) -> i8x16 {
+		cast!(self.simd128.i8x16_swizzle(cast!(table), cast!(idx)))
+	}
+}
+
 impl crate::seal::Seal for RelaxedSimd {}
 impl Simd for RelaxedSimd {
 	type c32s = f32x4;

--- a/pulp/src/x86/v2.rs
+++ b/pulp/src/x86/v2.rs
@@ -551,6 +551,24 @@ impl V2 {
 
 		(cast!(ab_lo), cast!(ab_hi))
 	}
+
+	/// Shuffles the bytes of `table` according to the byte indices in `idx`.
+	///
+	/// Semantics match the underlying `pshufb` (`_mm_shuffle_epi8`): if the high
+	/// bit of an index byte is set, the corresponding output byte is zero;
+	/// otherwise only the low 4 bits of the index are used to select a byte from
+	/// `table`. This is the fundamental 16-byte in-register lookup table (LUT)
+	/// primitive.
+	#[inline(always)]
+	pub fn shuffle_u8x16(self, table: u8x16, idx: u8x16) -> u8x16 {
+		cast!(self.ssse3._mm_shuffle_epi8(cast!(table), cast!(idx)))
+	}
+
+	/// Signed-byte variant of [`V2::shuffle_u8x16`].
+	#[inline(always)]
+	pub fn shuffle_i8x16(self, table: i8x16, idx: i8x16) -> i8x16 {
+		cast!(self.ssse3._mm_shuffle_epi8(cast!(table), cast!(idx)))
+	}
 }
 
 macro_rules! impl_simd_binop {

--- a/pulp/src/x86/v3.rs
+++ b/pulp/src/x86/v3.rs
@@ -4373,4 +4373,40 @@ impl V3 {
 
 		(cast!(ab_lo), cast!(ab_hi))
 	}
+
+	/// Shuffles the bytes of each 128-bit half of `table` independently using the
+	/// byte indices in the corresponding half of `idx`. This is the AVX2
+	/// `_mm256_shuffle_epi8` instruction: two parallel 16-byte lookups.
+	///
+	/// If the high bit of an index byte is set, the corresponding output byte is
+	/// zero; otherwise only the low 4 bits are used within that half.
+	///
+	/// For a full cross-lane 32-byte lookup, use [`V3::shuffle_u8x32`].
+	#[inline(always)]
+	pub fn shuffle_u8x32_in_lane(self, table: u8x32, idx: u8x32) -> u8x32 {
+		cast!(self.avx2._mm256_shuffle_epi8(cast!(table), cast!(idx)))
+	}
+
+	/// Signed-byte variant of [`V3::shuffle_u8x32_in_lane`].
+	#[inline(always)]
+	pub fn shuffle_i8x32_in_lane(self, table: i8x32, idx: i8x32) -> i8x32 {
+		cast!(self.avx2._mm256_shuffle_epi8(cast!(table), cast!(idx)))
+	}
+
+	/// Cross-lane 32-byte table lookup.
+	///
+	/// Each byte of `idx` selects a byte from the full 32-byte `table`. Indices
+	/// whose high bit is set or whose value is `>= 32` produce a zero output
+	/// byte. Emulated on AVX2 via two `vpshufb` lookups against duplicated
+	/// halves, blended by index range.
+	#[inline(always)]
+	pub fn shuffle_u8x32(self, table: u8x32, idx: u8x32) -> u8x32 {
+		cast!(avx2_pshufb(self, cast!(table), cast!(idx)))
+	}
+
+	/// Signed-byte variant of [`V3::shuffle_u8x32`].
+	#[inline(always)]
+	pub fn shuffle_i8x32(self, table: i8x32, idx: i8x32) -> i8x32 {
+		cast!(avx2_pshufb(self, cast!(table), cast!(idx)))
+	}
 }

--- a/pulp/src/x86/v4.rs
+++ b/pulp/src/x86/v4.rs
@@ -4123,6 +4123,29 @@ impl V4 {
 
 		(cast!(ab_lo), cast!(ab_hi))
 	}
+
+	/// Shuffles the bytes of each 128-bit quarter of `table` independently using
+	/// the byte indices in the corresponding quarter of `idx`. This is the
+	/// AVX-512BW `_mm512_shuffle_epi8` instruction: four parallel 16-byte
+	/// lookups.
+	///
+	/// If the high bit of an index byte is set, the corresponding output byte is
+	/// zero; otherwise only the low 4 bits are used within that quarter.
+	///
+	/// A full cross-lane 64-byte byte lookup would require AVX-512 VBMI
+	/// (`_mm512_permutexvar_epi8`), which is not part of the [`V4`] feature
+	/// level. For cross-lane 32-byte lookups, use [`V3::shuffle_u8x32`] (the
+	/// method is inherited by `V4` through `Deref`).
+	#[inline(always)]
+	pub fn shuffle_u8x64_in_lane(self, table: u8x64, idx: u8x64) -> u8x64 {
+		cast!(self.avx512bw._mm512_shuffle_epi8(cast!(table), cast!(idx)))
+	}
+
+	/// Signed-byte variant of [`V4::shuffle_u8x64_in_lane`].
+	#[inline(always)]
+	pub fn shuffle_i8x64_in_lane(self, table: i8x64, idx: i8x64) -> i8x64 {
+		cast!(self.avx512bw._mm512_shuffle_epi8(cast!(table), cast!(idx)))
+	}
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
## Summary

Exposes the in-register byte lookup-table (LUT) primitive that every supported backend already has but which pulp kept private (only used internally for `rotate_*` emulation on AVX2). Adds safe wrappers symmetric across x86, aarch64, and wasm.

## What's added

- **V2** (ssse3): `shuffle_{u8,i8}x16` — `_mm_shuffle_epi8`
- **V3** (avx2):
  - `shuffle_{u8,i8}x32_in_lane` — `_mm256_shuffle_epi8`, two parallel 16-byte lookups
  - `shuffle_{u8,i8}x32` — full cross-lane 32-byte lookup, reusing the existing `avx2_pshufb` helper (zero new code in the hot path)
- **V4** (avx512bw): `shuffle_{u8,i8}x64_in_lane` — `_mm512_shuffle_epi8`, four parallel 16-byte lookups
- **Neon**: `shuffle_{u8,i8}x16` — `vqtbl1q_{u8,s8}`
- **Simd128 / RelaxedSimd**: `shuffle_{u8,i8}x16` — `i8x16_swizzle`

The `Deref` chain (V4→V3→V2, NeonFcma→Neon) auto-inherits narrower-width shuffles, so e.g. `v4.shuffle_u8x32(...)` just works.

## Not included (scoped out)

- **V4 full cross-lane 64-byte byte shuffle**: requires `avx512vbmi` (`_mm512_permutexvar_epi8`), which isn't part of the V4 feature set. Adding it would either tighten V4's CPU requirements or warrant a new `V4Vbmi` struct — happy to do that in a follow-up PR if desired.
- 16-bit / 32-bit element permutes (`permutexvar_epi{16,32}`) — separate feature, not strictly "LUT".

## Semantics note

Each backend uses its native instruction's OOB semantics, documented on each method:
- x86 `pshufb`: high bit of index byte set → output byte is 0; otherwise low 4 bits used within the 128-bit lane
- NEON `tbl`, wasm `swizzle`: index `>= 16` → output byte is 0

These agree on valid indices `[0, 15]` and on indices with bit 7 set; they diverge for indices in `[16, 127]`. Docs call this out explicitly. A normalized "zero-OOB everywhere" variant could be added later, but the raw wrappers match the existing pulp style (thin safe shims over the intrinsics).

## Test plan

- [x] `cargo build -p pulp` on x86_64-apple-darwin
- [x] `cargo test -p pulp --lib` (4 passed)
- [x] `cargo check -p pulp --target aarch64-apple-darwin`
- [x] `cargo check -p pulp --target wasm32-unknown-unknown` with `RUSTFLAGS='-C target-feature=+simd128'`
- [x] `cargo clippy -p pulp --no-deps` clean on x86_64 and aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)