### PR TITLE
Add cargo feature for relaxed-simd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,20 @@ jobs:
       - name: Compile benches
         run: cargo bench --no-run
 
+  cargo-wasm-no-relaxed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Check wasm build without relaxed-simd
+        run: cargo check -p pulp --target wasm32-unknown-unknown --no-default-features --features std,x86-v3
+
   cargo-tests:
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+          targets: wasm32-unknown-unknown
 
       - name: Run cargo clippy
         run: cargo clippy --all-targets -- --no-deps -D warnings
@@ -42,6 +43,9 @@ jobs:
 
       - name: Run cargo clippy no_std x86-v4
         run: cargo clippy --no-default-features --features x86-v4 --all-targets -- --no-deps -D warnings
+
+      - name: Run cargo clippy wasm no relaxed-simd
+        run: cargo clippy -p pulp --lib --target wasm32-unknown-unknown --no-default-features --features std,x86-v3 -- --no-deps -D warnings
 
   clippy-nightly:
     name: clippy

--- a/pulp-wasm-simd-flag/Cargo.toml
+++ b/pulp-wasm-simd-flag/Cargo.toml
@@ -10,3 +10,7 @@ license = "MIT"
 keywords = ["simd"]
 
 [dependencies]
+
+[features]
+default = ["relaxed-simd"]
+relaxed-simd = []

--- a/pulp-wasm-simd-flag/src/lib.rs
+++ b/pulp-wasm-simd-flag/src/lib.rs
@@ -4,6 +4,7 @@
 mod wasm {
 	use core::sync::atomic;
 	static SIMD128: atomic::AtomicBool = atomic::AtomicBool::new(cfg!(target_feature = "simd128"));
+	#[cfg(feature = "relaxed-simd")]
 	static RELAXED_SIMD: atomic::AtomicBool =
 		atomic::AtomicBool::new(cfg!(target_feature = "relaxed-simd"));
 
@@ -14,6 +15,7 @@ mod wasm {
 
 	#[inline]
 	pub fn disable_simd128() {
+		#[cfg(feature = "relaxed-simd")]
 		disable_relaxed_simd();
 		SIMD128.store(false, atomic::Ordering::Relaxed);
 	}
@@ -24,17 +26,20 @@ mod wasm {
 	}
 
 	#[inline]
+	#[cfg(feature = "relaxed-simd")]
 	pub fn enable_relaxed_simd() {
 		enable_simd128();
 		RELAXED_SIMD.store(true, atomic::Ordering::Relaxed);
 	}
 
 	#[inline]
+	#[cfg(feature = "relaxed-simd")]
 	pub fn disable_relaxed_simd() {
 		RELAXED_SIMD.store(false, atomic::Ordering::Relaxed);
 	}
 
 	#[inline]
+	#[cfg(feature = "relaxed-simd")]
 	pub fn is_relaxed_simd_enabled() -> bool {
 		cfg!(target_feature = "relaxed-simd") || RELAXED_SIMD.load(atomic::Ordering::Relaxed)
 	}

--- a/pulp/Cargo.toml
+++ b/pulp/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["simd"]
 
 [dependencies]
 pulp-macro = { version = "0.1.1", path = "../pulp-macro", optional = true }
-pulp-wasm-simd-flag = { version = "0.1", path = "../pulp-wasm-simd-flag" }
+pulp-wasm-simd-flag = { version = "0.1", path = "../pulp-wasm-simd-flag", default-features = false }
 bytemuck = { version = "1.15", features = ["aarch64_simd", "wasm_simd"] }
 num-complex = { version = "0.4.4", default-features = false, features = ["bytemuck"] }
 libm = { version = "0.2", default-features = false }
@@ -26,6 +26,7 @@ raw-cpuid = { version = "11.5.0", default-features = false }
 default = [
   "std",
   "x86-v3",
+  "relaxed-simd",
 ]
 nightly = [
   "bytemuck/nightly_stdsimd",
@@ -36,6 +37,8 @@ x86-v3 = []
 x86-v4 = [
   "bytemuck/avx512_simd",
 ]
+
+relaxed-simd = ["pulp-wasm-simd-flag/relaxed-simd"]
 
 macro = ["dep:pulp-macro"]
 

--- a/pulp/src/core_arch/mod.rs
+++ b/pulp/src/core_arch/mod.rs
@@ -70,9 +70,16 @@ macro_rules! feature_detected {
 	("simd128") => {
 		$crate::wasm::is_simd128_enabled()
 	};
-	("relaxed-simd") => {
-		$crate::wasm::is_relaxed_simd_enabled()
-	};
+	("relaxed-simd") => {{
+		#[cfg(feature = "relaxed-simd")]
+		{
+			$crate::wasm::is_relaxed_simd_enabled()
+		}
+		#[cfg(not(feature = "relaxed-simd"))]
+		{
+			false
+		}
+	}};
 }
 
 #[cfg(all(
@@ -230,13 +237,22 @@ macro_rules! __impl_type {
 #[doc(hidden)]
 pub struct Unavailable<const N: usize>;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature = "relaxed-simd"))]
 #[doc(hidden)]
 #[rustfmt::skip]
 #[macro_export]
 macro_rules! __impl_type {
     ("simd128") => { $crate::core_arch::wasm::Simd128 };
     ("relaxed-simd") => { $crate::core_arch::wasm::RelaxedSimd };
+}
+
+#[cfg(all(target_arch = "wasm32", not(feature = "relaxed-simd")))]
+#[doc(hidden)]
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! __impl_type {
+    ("simd128") => { $crate::core_arch::wasm::Simd128 };
+    ("relaxed-simd") => { $crate::core_arch::Unavailable::<{compile_error!("enable the `relaxed-simd` feature to use wasm relaxed-simd")}> };
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64", target_arch = "wasm32")))]

--- a/pulp/src/core_arch/wasm/mod.rs
+++ b/pulp/src/core_arch/wasm/mod.rs
@@ -7,6 +7,7 @@ pub struct Simd128 {
 	__private: (),
 }
 
+#[cfg(feature = "relaxed-simd")]
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct RelaxedSimd {
@@ -20,6 +21,7 @@ impl core::fmt::Debug for Simd128 {
 	}
 }
 
+#[cfg(feature = "relaxed-simd")]
 impl core::fmt::Debug for RelaxedSimd {
 	#[inline]
 	fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -49,6 +51,7 @@ impl Simd128 {
 	}
 }
 
+#[cfg(feature = "relaxed-simd")]
 impl RelaxedSimd {
 	#[inline(always)]
 	/// requires the corresponding feature
@@ -444,6 +447,7 @@ impl Simd128 {
 	});
 }
 
+#[cfg(feature = "relaxed-simd")]
 impl RelaxedSimd {
 	delegate!({
 		fn i8x16_relaxed_swizzle(a: v128, s: v128) -> v128;

--- a/pulp/src/lib.rs
+++ b/pulp/src/lib.rs
@@ -223,7 +223,8 @@ use seal::Seal;
 #[cfg_attr(docsrs, doc(cfg(feature = "macro")))]
 pub use pulp_macro::with_simd;
 
-pub use {bytemuck, num_complex};
+pub use bytemuck;
+pub use num_complex;
 
 pub type c32 = Complex<f32>;
 pub type c64 = Complex<f64>;

--- a/pulp/src/wasm.rs
+++ b/pulp/src/wasm.rs
@@ -7,6 +7,7 @@ simd_type!({
 		pub simd128: f!("simd128"),
 	}
 
+	#[cfg(feature = "relaxed-simd")]
 	#[allow(missing_docs)]
 	pub struct RelaxedSimd {
 		pub simd128: f!("simd128"),
@@ -1201,7 +1202,9 @@ impl Simd for Simd128 {
 	}
 }
 
+#[cfg(feature = "relaxed-simd")]
 impl crate::seal::Seal for RelaxedSimd {}
+#[cfg(feature = "relaxed-simd")]
 impl Simd for RelaxedSimd {
 	type c32s = f32x4;
 	type c64s = f64x2;
@@ -2430,6 +2433,7 @@ fn max_f64(a: f64, b: f64) -> f64 {
 pub enum Arch {
 	Scalar = 0,
 
+	#[cfg(feature = "relaxed-simd")]
 	RelaxedSimd(RelaxedSimd),
 	Simd128(Simd128),
 }
@@ -2438,6 +2442,7 @@ impl Arch {
 	/// Detects the best available instruction set.
 	#[inline]
 	pub fn new() -> Self {
+		#[cfg(feature = "relaxed-simd")]
 		if let Some(simd) = RelaxedSimd::try_new() {
 			return Self::RelaxedSimd(simd);
 		}
@@ -2451,6 +2456,7 @@ impl Arch {
 	#[inline(always)]
 	pub fn dispatch<Op: WithSimd>(self, op: Op) -> Op::Output {
 		match self {
+			#[cfg(feature = "relaxed-simd")]
 			Arch::RelaxedSimd(simd) => Simd::vectorize(simd, op),
 			Arch::Simd128(simd) => Simd::vectorize(simd, op),
 


### PR DESCRIPTION
Safari doesn't support relaxed simd out of the box. It validates the wasm module on load, so the instructions must not be present, even if they are never run.

This PR adds a `relaxed-simd` cargo feature. It's enabled by default so that the change is backward compatible with existing use.